### PR TITLE
feat(token-issuer): implement real Apple App Attest validation

### DIFF
--- a/token-issuer/README.md
+++ b/token-issuer/README.md
@@ -138,9 +138,32 @@ so they self-expire when the epoch rolls.
 | `APPLE_TEAM_ID` | unset | your Apple Team ID. Required to enforce App Attest |
 | `APPLE_BUNDLE_ID` | unset | Lander's bundle id. Required to enforce App Attest |
 | `APPLE_APP_ATTEST_AAGUID` | `appattest` | `appattest` for production, `appattestdevelop` for dev/TestFlight builds |
+| `APP_ATTEST_CLOCK_SKEW_MS` | `300000` | tolerance (ms) when checking the x5c certs' validity windows, for issuer/Apple clock drift |
+| `REQUIRE_CLIENT_DATA_BINDING` | `1` (on) | require the App Attest `clientDataHash` to commit to the exact `blinded[]` batch + epoch (see below). Set to `0` only during client bring-up, before the iOS client computes the matching hash |
 
 The signing key is injected exactly like the gateway's `SEED_SECRET_KEY`: from your
 host's secret store at runtime, never written to disk in this repo.
+
+### Request-payload binding (`clientDataHash` ↔ `blinded[]`)
+
+App Attest proves "a genuine device signed this 32-byte `clientDataHash`." On its
+own that authenticates the device but not the request: a captured valid
+`{keyId, assertion, clientDataHash}` could be replayed against a *different*
+`blinded[]` batch (still bounded by the per-device quota, but not request-integrity
+checked). With `REQUIRE_CLIENT_DATA_BINDING=1` (the default), the issuer requires
+
+```
+clientDataHash == SHA-256( utf8(epoch) || 0x00 || blinded[0] || 0x00 || blinded[1] || 0x00 ... )
+```
+
+where each `blinded[i]` is the raw (base64-decoded) blinded message, so the
+attestation/assertion is bound to the exact tokens being requested in this epoch
+(the current or previous epoch is accepted, to tolerate an epoch-boundary crossing).
+**The iOS client must compute its App Attest challenge as this same hash.** Until
+that client change ships, run with `REQUIRE_CLIENT_DATA_BINDING=0` (App Attest then
+bounds abuse per-device but does not bind the payload) and flip it on once the
+client matches. This is the one piece of the App Attest gate whose other half lives
+in the Lander app.
 
 ## What is production ready vs what still needs work
 
@@ -162,27 +185,54 @@ these pieces.
   issuer rejects every request rather than issuing under a key nobody controls or
   to a device nobody verified.
 
+**Implemented:**
+
+- **Apple App Attest validation** (`appattest.js`). The full server-side check is
+  now implemented, per Apple's "Validating Apps That Connect to Your Server through
+  App Attest":
+  - *Attestation* (one-time device registration): CBOR-decode the attestation
+    object, verify the `x5c` certificate chain anchors to Apple's App Attest Root
+    CA (real X.509 path + signature + validity checks via node's
+    `crypto.X509Certificate`), verify the nonce in the leaf cert's
+    `1.2.840.113635.100.8.2` extension equals `SHA256(authData || clientDataHash)`,
+    verify `rpIdHash == SHA256(appID)`, verify the AAGUID matches the configured
+    environment (`appattest` prod / `appattestdevelop` dev), verify `signCount == 0`,
+    bind the keyId to `SHA256` of the credential's uncompressed EC point, and
+    extract the device public key for storage.
+  - *Assertion* (per issuance): verify the ECDSA-P256-SHA256 signature over
+    `SHA256(authData || clientDataHash)` with the stored device key, re-check
+    `rpIdHash`, and enforce a strictly increasing sign counter.
+
+  It still **fails closed**: with `APPLE_APP_ATTEST_ROOT_CA_PEM_B64`,
+  `APPLE_TEAM_ID`, or `APPLE_BUNDLE_ID` unset, the validator rejects every request,
+  and any failed check rejects the request. There is no silent-allow path.
+
+  The validation logic is exercised by `appattest.test.js` against a synthetic
+  trust chain (a self-minted CA + leaf, built in pure JS in `appattest-fixtures.js`)
+  that satisfies every Apple check, plus negative tests that each tampered field is
+  rejected. The one remaining gap is a **real-device fixture**: a captured
+  attestation/assertion from a physical iPhone running Lander, validated against
+  Apple's real Root CA, to confirm byte-compatibility with Apple's actual encoder.
+  See the repo's roadmap and the PR notes for exactly how to capture one.
+
 **Stubbed, and clearly marked as such:**
 
-- **Apple App Attest validation** (`appattest.js`). The full structure is there,
-  with every Apple-defined check as its own labeled function: cert chain to Apple's
-  App Attest Root CA, nonce binding, key-id binding, rpId/appID hash, aaguid, and
-  the assertion's monotonic sign counter. Each one that cannot be completed without
-  operator input (Apple's root cert, your team and bundle id) or without CBOR/X.509
-  parsing is a `STUB` that returns `false` with a precise `TODO`. The module
-  fails closed until `APPLE_APP_ATTEST_ROOT_CA_PEM_B64`, `APPLE_TEAM_ID`, and
-  `APPLE_BUNDLE_ID` are supplied AND the parsing is filled in. There is no
-  silent-allow path. Wiring this up is the main remaining task before production.
-
-- **Persistent quota and redemption state.** Both the issuer's per-device per-epoch
-  quota and the relay's spend-once set are in-memory and single-process. That is
-  fine for a first cut and for a single replica, but it has two gaps for a real
-  multi-replica deployment: a device could get its full quota from each replica,
-  and a restart forgets prior spends. The code marks exactly where a shared atomic
-  store goes (Redis `INCR`/`EXPIRE` for the quota keyed by a salted device hash,
-  Redis `SET NX` with an epoch TTL for the redemption nullifiers). The nullifier is
-  derived from the token signature only and carries no identity, so the store never
-  holds anything user-linking.
+- **Persistent quota, redemption, and attested-key state.** The issuer's per-device
+  per-epoch quota, the relay's spend-once set, and the App Attest attested-key store
+  (device public key + last sign counter per keyId) are all in-memory and
+  single-process. That is fine for a first cut and for a single replica, but it has
+  gaps for a real multi-replica deployment: a device could get its full quota from
+  each replica, a restart forgets prior spends, and a device registered on one
+  replica is unknown to another (its assertions are rejected as `unknown_device_key`
+  until it re-attests; the Lander client handles this by re-attesting on rejection).
+  The code marks exactly where a shared atomic store goes (Redis `INCR`/`EXPIRE` for
+  the quota keyed by a salted device hash, Redis `SET NX` with an epoch TTL for the
+  redemption nullifiers, and a Redis hash per keyId for the attested key with a
+  compare-and-set on the sign counter so concurrent assertions cannot both pass with
+  the same counter). The nullifier is derived from the token signature only and
+  carries no identity; the attested key is device-PUBLIC material, and the store is
+  keyed by a salted hash of the keyId, so the store never holds anything
+  user-linking.
 
 - **Attester / Issuer split.** Right now one service plays both Privacy Pass roles.
   RFC 9576 allows splitting the Attester (which sees the device) from the Issuer
@@ -234,9 +284,50 @@ npm install
 node --test
 ```
 
-The suite proves the blind-sign roundtrip, relay acceptance of a valid token,
+Run them under the deploy runtime (`node:20.18.1-alpine`), not a newer local node,
+since a node-version mismatch has crashed this service in production before:
+
+```sh
+# from the repo root (the Privacy Pass test imports the sibling relay)
+docker run --rm -v "$PWD":/repo -w /repo/token-issuer node:20.18.1-alpine \
+  sh -c 'npm ci && npm test'
+```
+
+`test.js` proves the blind-sign roundtrip, relay acceptance of a valid token,
 double-spend rejection, tampered/forged-token rejection, an unlinkability sanity
-check, and the quota accounting.
+check, the quota accounting, and a real-entrypoint boot.
+
+`appattest.test.js` proves the App Attest validator: a well-formed (synthetic)
+attestation is accepted and returns the device key, an assertion from that key
+verifies and advances the sign counter, and each tampered field is rejected on its
+own (wrong rpIdHash, wrong challenge/nonce, broken chain, untrusted root, wrong
+aaguid, non-zero first counter, forged keyId, bad assertion signature,
+non-increasing counter, unknown device key), plus fail-closed behaviour on missing
+inputs. The synthetic trust chain is built in pure JS in `appattest-fixtures.js`
+(a test helper; it is not imported by `server.js` and is not copied into the image).
+
+### Capturing a real-device fixture (required follow-up)
+
+The synthetic fixtures substitute one thing only - the trust anchor (our test root
+in place of Apple's Root CA, injected exactly as an operator injects the real root).
+Every cryptographic and structural check is the production one. Still, before
+trusting this in production you should validate one **real** attestation from a
+physical iPhone running Lander, against Apple's real Root CA, to confirm
+byte-compatibility with Apple's actual CBOR/X.509 encoder. Two ways:
+
+1. **Debug capture endpoint (temporary).** Add a short-lived `POST /attest-debug`
+   to a NON-production instance that takes `{ keyId, attestation, clientDataHash }`,
+   runs `validateAppAttest` with the real `APPLE_*` env set, and returns the result
+   (and, in debug only, the failing check). Drive it from the Lander client's App
+   Attest code path once, capture the request body, then **remove the endpoint**.
+2. **Captured fixture (preferred, permanent regression).** Have the Lander client
+   log one real `attestation` + `clientDataHash` + `keyId` for a known challenge,
+   paste them into a new test alongside the **real** Apple Root CA PEM (base64), and
+   assert `validateAppAttest` returns `ok: true`. Because a real attestation is not
+   user-linking once the challenge is discarded, this fixture is safe to commit.
+
+Until that fixture exists, treat App Attest as "implemented and unit-proven against
+a synthetic chain, pending one real-device confirmation."
 
 ## Dependencies
 

--- a/token-issuer/appattest-fixtures.js
+++ b/token-issuer/appattest-fixtures.js
@@ -1,0 +1,361 @@
+// Columbia - synthetic App Attest fixtures for tests.
+//
+// We have NO real device attestation in CI, and node has no built-in X.509
+// builder, and the deploy image (node:20-alpine) ships no openssl CLI. So to prove
+// the validator ACCEPTS a well-formed attestation - and REJECTS each tampered
+// variant - we mint a synthetic trust chain and a hand-built attestation object in
+// pure JavaScript here:
+//
+//   * a self-signed P-256 "root" CA (stands in for Apple's App Attest Root CA),
+//   * a P-256 leaf "credCert" signed by that root, carrying the Apple nonce
+//     extension (OID 1.2.840.113635.100.8.2),
+//   * a WebAuthn-style authenticatorData with the attested EC credential key,
+//   * the CBOR attestation object Apple's fmt "apple-appattest" produces.
+//
+// The validator under test does not know these are synthetic: it does the exact
+// same chain/nonce/keyId/rpIdHash/aaguid checks it would do on a real Apple
+// attestation. The ONLY substitution is the trust anchor (our root instead of
+// Apple's), injected via APPLE_APP_ATTEST_ROOT_CA_PEM_B64 - which is exactly the
+// operator-supplied pin in production. This is the strongest test possible without
+// a physical device; a real-device fixture is still required (see PR notes).
+//
+// This file is a TEST helper only. It is not imported by server.js and is not
+// copied into the Docker image.
+
+import crypto from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Minimal DER encoders (just what an X.509 cert needs).
+// ---------------------------------------------------------------------------
+
+function derLen(n) {
+  if (n < 0x80) return Buffer.from([n]);
+  const bytes = [];
+  let v = n;
+  while (v > 0) { bytes.unshift(v & 0xff); v >>= 8; }
+  return Buffer.from([0x80 | bytes.length, ...bytes]);
+}
+
+function tlv(tag, content) {
+  return Buffer.concat([Buffer.from([tag]), derLen(content.length), content]);
+}
+
+function derSeq(...items) { return tlv(0x30, Buffer.concat(items)); }
+function derSet(...items) { return tlv(0x31, Buffer.concat(items)); }
+function derOctetString(buf) { return tlv(0x04, buf); }
+function derBoolean(b) { return tlv(0x01, Buffer.from([b ? 0xff : 0x00])); }
+function derContext(tagNum, constructed, content) {
+  const tag = 0x80 | (constructed ? 0x20 : 0x00) | tagNum;
+  return tlv(tag, content);
+}
+
+function derInteger(value) {
+  // small non-negative integer (serial)
+  let bytes = [];
+  let v = value;
+  if (v === 0) bytes = [0];
+  else { while (v > 0) { bytes.unshift(v & 0xff); v = Math.floor(v / 256); } }
+  if (bytes[0] & 0x80) bytes.unshift(0x00); // keep positive
+  return tlv(0x02, Buffer.from(bytes));
+}
+
+function derOid(dotted) {
+  const parts = dotted.split('.').map((x) => parseInt(x, 10));
+  const bytes = [40 * parts[0] + parts[1]];
+  for (let i = 2; i < parts.length; i++) {
+    let v = parts[i];
+    const stack = [v & 0x7f];
+    v >>= 7;
+    while (v > 0) { stack.unshift((v & 0x7f) | 0x80); v >>= 7; }
+    for (const b of stack) bytes.push(b);
+  }
+  return tlv(0x06, Buffer.from(bytes));
+}
+
+function derUtcTime(date) {
+  // YYMMDDHHMMSSZ
+  const p = (n) => String(n).padStart(2, '0');
+  const s = p(date.getUTCFullYear() % 100) + p(date.getUTCMonth() + 1) + p(date.getUTCDate()) +
+            p(date.getUTCHours()) + p(date.getUTCMinutes()) + p(date.getUTCSeconds()) + 'Z';
+  return tlv(0x17, Buffer.from(s, 'ascii'));
+}
+
+// A minimal RDN: CN=<commonName>.
+function derName(commonName) {
+  const cnOid = derOid('2.5.4.3'); // commonName
+  const cnVal = tlv(0x0c, Buffer.from(commonName, 'utf8')); // UTF8String
+  return derSeq(derSet(derSeq(cnOid, cnVal)));
+}
+
+// ecdsa-with-SHA256 AlgorithmIdentifier: SEQUENCE { OID 1.2.840.10045.4.3.2 }.
+function ecdsaWithSha256AlgId() {
+  return derSeq(derOid('1.2.840.10045.4.3.2'));
+}
+
+// SubjectPublicKeyInfo for an EC P-256 public key, from a node KeyObject.
+function spkiFromKey(publicKey) {
+  // node exports SPKI DER directly; reuse it verbatim.
+  return publicKey.export({ type: 'spki', format: 'der' });
+}
+
+// The Apple nonce extension: extnValue OCTET STRING wraps
+//   SEQUENCE { [1] EXPLICIT OCTET STRING nonce }.
+function appleNonceExtension(nonce32) {
+  const inner = derSeq(derContext(1, true, derOctetString(nonce32)));
+  return derSeq(
+    derOid('1.2.840.113635.100.8.2'),
+    derOctetString(inner), // extnValue
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Cert builder. Builds a TBSCertificate, signs it with the issuer key (ECDSA
+// P-256 / SHA-256), and assembles the full Certificate. Returns DER bytes.
+// ---------------------------------------------------------------------------
+
+function buildCert({ subjectCN, issuerCN, subjectKey, issuerKey, serial, extensions = [], notBefore, notAfter }) {
+  const nb = notBefore || new Date(Date.now() - 3600 * 1000);
+  const na = notAfter || new Date(Date.now() + 24 * 3600 * 1000);
+
+  const version = derContext(0, true, derInteger(2)); // v3
+  const tbsPieces = [
+    version,
+    derInteger(serial),
+    ecdsaWithSha256AlgId(),
+    derName(issuerCN),
+    derSeq(derUtcTime(nb), derUtcTime(na)),
+    derName(subjectCN),
+    spkiFromKey(subjectKey),
+  ];
+  if (extensions.length) {
+    tbsPieces.push(derContext(3, true, derSeq(...extensions))); // [3] EXPLICIT Extensions
+  }
+  const tbs = derSeq(...tbsPieces);
+
+  // Sign the TBSCertificate. node emits a DER ECDSA signature, which is exactly
+  // the BIT STRING content X.509 wants.
+  const sig = crypto.sign('sha256', tbs, issuerKey);
+  const sigBitString = tlv(0x03, Buffer.concat([Buffer.from([0x00]), sig])); // BIT STRING, 0 unused bits
+
+  return derSeq(tbs, ecdsaWithSha256AlgId(), sigBitString);
+}
+
+function newP256() {
+  return crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+}
+
+function pemCert(der) {
+  const b64 = der.toString('base64').replace(/(.{64})/g, '$1\n');
+  return `-----BEGIN CERTIFICATE-----\n${b64}\n-----END CERTIFICATE-----\n`;
+}
+
+function uncompressedPoint(publicKey) {
+  const jwk = publicKey.export({ format: 'jwk' });
+  return Buffer.concat([
+    Buffer.from([0x04]),
+    Buffer.from(jwk.x, 'base64url'),
+    Buffer.from(jwk.y, 'base64url'),
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// CBOR encoders (the small subset App Attest uses).
+// ---------------------------------------------------------------------------
+
+function cborUint(n) {
+  if (n < 24) return Buffer.from([n]);
+  if (n < 256) return Buffer.from([0x18, n]);
+  if (n < 65536) { const b = Buffer.alloc(3); b[0] = 0x19; b.writeUInt16BE(n, 1); return b; }
+  const b = Buffer.alloc(5); b[0] = 0x1a; b.writeUInt32BE(n, 1); return b;
+}
+function cborNegInt(n) {
+  // n is negative; encode major type 1 with value (-1 - n)
+  const m = -1 - n;
+  const u = cborUint(m);
+  u[0] = (u[0] & 0x1f) | 0x20;
+  return u;
+}
+function cborBytes(buf) {
+  const head = cborUint(buf.length); head[0] = (head[0] & 0x1f) | 0x40;
+  return Buffer.concat([head, buf]);
+}
+function cborText(str) {
+  const b = Buffer.from(str, 'utf8');
+  const head = cborUint(b.length); head[0] = (head[0] & 0x1f) | 0x60;
+  return Buffer.concat([head, b]);
+}
+function cborArray(items) {
+  const head = cborUint(items.length); head[0] = (head[0] & 0x1f) | 0x80;
+  return Buffer.concat([head, ...items]);
+}
+// map from an ordered list of [keyBuf, valBuf] pairs
+function cborMap(pairs) {
+  const head = cborUint(pairs.length); head[0] = (head[0] & 0x1f) | 0xa0;
+  return Buffer.concat([head, ...pairs.flatMap(([k, v]) => [k, v])]);
+}
+
+// COSE_Key for an EC2 P-256 ES256 public key.
+function coseKeyFor(publicKey) {
+  const jwk = publicKey.export({ format: 'jwk' });
+  const x = Buffer.from(jwk.x, 'base64url');
+  const y = Buffer.from(jwk.y, 'base64url');
+  // Ordered: 1:2 (kty EC2), 3:-7 (ES256), -1:1 (P-256), -2:x, -3:y
+  return cborMap([
+    [cborUint(1), cborUint(2)],
+    [cborUint(3), cborNegInt(-7)],
+    [cborNegInt(-1), cborUint(1)],
+    [cborNegInt(-2), cborBytes(x)],
+    [cborNegInt(-3), cborBytes(y)],
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// authenticatorData builders.
+// ---------------------------------------------------------------------------
+
+function aaguidBuf(label) {
+  const out = Buffer.alloc(16);
+  Buffer.from(label, 'ascii').copy(out, 0, 0, 16);
+  return out;
+}
+
+// Attestation authData: rpIdHash | flags(AT) | signCount(0) | aaguid | credIdLen |
+// credentialId | COSE_Key.
+function buildAttestationAuthData({ rpIdHash, aaguidLabel, credentialId, credentialKey, signCount = 0, flags = 0x40 }) {
+  const head = Buffer.alloc(37);
+  rpIdHash.copy(head, 0);
+  head[32] = flags;
+  head.writeUInt32BE(signCount, 33);
+  const aaguid = aaguidBuf(aaguidLabel);
+  const credIdLen = Buffer.alloc(2); credIdLen.writeUInt16BE(credentialId.length, 0);
+  const cose = coseKeyFor(credentialKey);
+  return Buffer.concat([head, aaguid, credIdLen, credentialId, cose]);
+}
+
+// Assertion authData: rpIdHash | flags | signCount  (no attestedCredentialData).
+function buildAssertionAuthData({ rpIdHash, signCount, flags = 0x00 }) {
+  const b = Buffer.alloc(37);
+  rpIdHash.copy(b, 0);
+  b[32] = flags;
+  b.writeUInt32BE(signCount, 33);
+  return b;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level fixture: a complete, valid synthetic attestation for a given appID,
+// aaguid label, and a 32-byte challenge. Returns everything the tests need plus
+// the building blocks so a test can tamper one field and rebuild.
+// ---------------------------------------------------------------------------
+
+function makeAttestationFixture({ appId, aaguidLabel = 'appattest', challenge }) {
+  const rpIdHash = crypto.createHash('sha256').update(appId, 'utf8').digest();
+  const clientDataHash = crypto.createHash('sha256').update(challenge).digest();
+
+  // Device credential key (the hardware key App Attest would create).
+  const credKey = newP256();
+  const credPoint = uncompressedPoint(credKey.publicKey);
+  const keyIdRaw = crypto.createHash('sha256').update(credPoint).digest(); // == credentialId
+  const credentialId = keyIdRaw;
+
+  // Root CA (stands in for Apple's App Attest Root CA).
+  const rootKey = newP256();
+  const rootDer = buildCert({
+    subjectCN: 'Columbia Test App Attest Root CA',
+    issuerCN: 'Columbia Test App Attest Root CA',
+    subjectKey: rootKey.publicKey,
+    issuerKey: rootKey.privateKey,
+    serial: 1,
+  });
+
+  // Intermediate CA, signed by the root. Real Apple x5c carries the leaf AND an
+  // intermediate ("Apple App Attestation CA 1"); modelling two certs exercises the
+  // multi-hop chain walk, not just a single leaf-under-root link.
+  const interKey = newP256();
+  const interDer = buildCert({
+    subjectCN: 'Columbia Test App Attestation CA 1',
+    issuerCN: 'Columbia Test App Attest Root CA',
+    subjectKey: interKey.publicKey,
+    issuerKey: rootKey.privateKey,
+    serial: 100,
+  });
+
+  // authData first (the nonce is computed over it).
+  const authData = buildAttestationAuthData({ rpIdHash, aaguidLabel, credentialId, credentialKey: credKey.publicKey });
+
+  // nonce = SHA-256(authData || clientDataHash), placed in the leaf cert extension.
+  const nonce = crypto.createHash('sha256').update(authData).update(clientDataHash).digest();
+
+  // Leaf credCert: subject key = the SAME device credential key; signed by the
+  // INTERMEDIATE (as Apple's credCert is signed by the App Attestation CA, not the
+  // root directly).
+  const leafDer = buildCert({
+    subjectCN: 'Columbia Test App Attest Credential',
+    issuerCN: 'Columbia Test App Attestation CA 1',
+    subjectKey: credKey.publicKey,
+    issuerKey: interKey.privateKey,
+    serial: 2,
+    extensions: [appleNonceExtension(nonce)],
+  });
+
+  // CBOR attestation object: { fmt, attStmt:{ x5c:[leaf, intermediate] }, authData }.
+  // Apple orders x5c leaf-first, intermediate-second; the root is the operator's pin.
+  const attObj = cborMap([
+    [cborText('fmt'), cborText('apple-appattest')],
+    [cborText('attStmt'), cborMap([
+      [cborText('x5c'), cborArray([cborBytes(leafDer), cborBytes(interDer)])],
+    ])],
+    [cborText('authData'), cborBytes(authData)],
+  ]);
+
+  return {
+    appId,
+    challenge,
+    clientDataHashB64: clientDataHash.toString('base64'),
+    keyIdB64: keyIdRaw.toString('base64'),
+    keyIdRaw,
+    rootPemB64: Buffer.from(pemCert(rootDer)).toString('base64'),
+    attestationB64: attObj.toString('base64'),
+    // Building blocks for negative tests:
+    rootKey, interKey, credKey, credentialId, rpIdHash, authData, nonce,
+    leafDer, interDer, rootDer, aaguidLabel,
+    // re-exported encoders/builders so tests can rebuild a tampered variant:
+    helpers: {
+      buildCert, appleNonceExtension, buildAttestationAuthData, buildAssertionAuthData,
+      cborMap, cborArray, cborBytes, cborText, pemCert, uncompressedPoint, aaguidBuf,
+    },
+  };
+}
+
+// Build a valid assertion for a registered key: signs SHA-256(authData ||
+// clientDataHash) with the device key, with a chosen signCount.
+function makeAssertion({ appId, credPrivateKey, signCount, challenge }) {
+  const rpIdHash = crypto.createHash('sha256').update(appId, 'utf8').digest();
+  const clientDataHash = crypto.createHash('sha256').update(challenge).digest();
+  const authData = buildAssertionAuthData({ rpIdHash, signCount });
+  const nonce = crypto.createHash('sha256').update(authData).update(clientDataHash).digest();
+  const signature = crypto.sign('sha256', nonce, credPrivateKey); // DER ECDSA
+  const assertionObj = cborMap([
+    [cborText('signature'), cborBytes(signature)],
+    [cborText('authenticatorData'), cborBytes(authData)],
+  ]);
+  return {
+    assertionB64: assertionObj.toString('base64'),
+    clientDataHashB64: clientDataHash.toString('base64'),
+    authData,
+  };
+}
+
+export {
+  makeAttestationFixture,
+  makeAssertion,
+  buildCert,
+  newP256,
+  pemCert,
+  uncompressedPoint,
+  appleNonceExtension,
+  buildAttestationAuthData,
+  buildAssertionAuthData,
+  coseKeyFor,
+  cborMap, cborArray, cborBytes, cborText, cborUint, cborNegInt,
+  aaguidBuf,
+};

--- a/token-issuer/appattest.js
+++ b/token-issuer/appattest.js
@@ -2,34 +2,29 @@
 //
 // This module is the gate that proves an /issue request comes from a genuine,
 // unmodified Lander install on real Apple hardware, before the issuer will
-// blind-sign any tokens. It implements Apple's DCAppAttestService verification.
+// blind-sign any tokens. It implements the server side of Apple's
+// DCAppAttestService: the one-time ATTESTATION that registers a hardware-backed
+// key, and the per-request ASSERTION that proves possession of that key.
 //
-// HONESTY NOTICE - READ THIS:
-//   The full Apple App Attest verification has several cryptographic steps
-//   (cert-chain to Apple's App Attest root, nonce binding, rpId/appID hash,
-//   sign-counter monotonicity). Doing them correctly requires two things this
-//   open-source repo deliberately does NOT carry:
-//     1. Apple's App Attest Root CA certificate (public, but pinned per operator).
-//     2. The operator's Apple Team ID + app Bundle ID (the appID = teamId.bundleId).
-//   Until BOTH are supplied (via env, see APPLE_* below) this module FAILS CLOSED:
-//   validateAppAttest() returns false and the issuer rejects every request. There
-//   is no silent-allow path. A stub check below that cannot be completed without
-//   operator input throws/returns false and is labeled with a TODO.
+// Reference: Apple, "Validating Apps That Connect to Your Server through App
+// Attest." App Attest reuses the WebAuthn authenticator-data layout (rpIdHash |
+// flags | signCount | attestedCredentialData), with an Apple-specific
+// attestation format ("apple-appattest"), an Apple anonymous attestation CA, and
+// the nonce carried in the leaf cert extension OID 1.2.840.113635.100.8.2.
 //
-// The structure here is the real, full verification flow. Each Apple-defined check
-// is its own clearly-named function so an operator can supply the missing inputs
-// and turn the stub into enforcement without restructuring anything. Where a step
-// genuinely needs CBOR/X.509 parsing that a dependency-light first cut can't do
-// safely, the function is marked STUB with a precise TODO of what to parse and
-// which Apple doc section governs it.
+// FAIL-CLOSED BY DESIGN: every check returns/throws on anything it cannot fully
+// verify, and validateAppAttest() returns { ok: false } unless EVERY applicable
+// check passes. If the operator has not supplied Apple's root CA and the app
+// identity (team + bundle id), the module refuses to even attempt verification.
+// There is no silent-allow path anywhere.
 //
-// References:
-//   Apple, "Validating Apps That Connect to Your Server" (App Attest server-side
-//   verification: attestation object, authenticator data, nonce, rpId hash,
-//   sign count, cert chain to the App Attest Root CA).
-//   Apple App Attest Root CA: https://www.apple.com/certificateauthority/
-
-// Native ES module (the package is ESM; see server.js for why).
+// DEPENDENCY POSTURE: no new runtime dependency. CBOR decoding and the ASN.1 walk
+// needed to pull one extension out of the leaf cert are done with small, bounded,
+// purpose-built parsers in this file (App Attest objects use only a tiny CBOR
+// subset). All cryptographic work - cert-chain signature verification, ECDSA
+// assertion verification, SHA-256 - uses node's built-in `crypto` only. We do NOT
+// hand-roll any crypto primitive; we only hand-roll structural parsing, which is
+// the safe, dependency-light part.
 
 import crypto from 'node:crypto';
 
@@ -37,172 +32,602 @@ import crypto from 'node:crypto';
 
 // Apple's App Attest Root CA, PEM, base64-encoded into one env var (so it is not
 // committed to this public repo). Download from Apple's certificate authority page
-// and inject at runtime. TODO(operator): supply APPLE_APP_ATTEST_ROOT_CA_PEM_B64.
+// (Apple_App_Attestation_Root_CA.pem) and inject at runtime.
 const APPLE_ROOT_CA_PEM_B64 = process.env.APPLE_APP_ATTEST_ROOT_CA_PEM_B64 || '';
 
 // The app identity the attestation must match: appID = "<TeamID>.<BundleID>".
-// e.g. ABCDE12345.com.example.Lander. TODO(operator): supply both.
+// e.g. PRWUVMURYJ.com.wbs.lander
 const APPLE_TEAM_ID = process.env.APPLE_TEAM_ID || '';
 const APPLE_BUNDLE_ID = process.env.APPLE_BUNDLE_ID || '';
 
 // Apple's production App Attest environment uses the aaguid "appattest" (dev uses
-// "appattestdevelop"). Operators on TestFlight/dev builds set this to the dev value.
-const EXPECTED_AAGUID = process.env.APPLE_APP_ATTEST_AAGUID || 'appattest';
+// "appattestdevelop"). Operators on a development/TestFlight provisioning profile
+// set this to the dev value. Both are 16-byte aaguids: the ASCII bytes of the
+// label, zero-padded to 16 bytes.
+const EXPECTED_AAGUID_LABEL = process.env.APPLE_APP_ATTEST_AAGUID || 'appattest';
+
+// Apple's App Attest leaf certs are short-lived but the attestation is validated
+// once, immediately, at registration. We accept a small clock skew (seconds) when
+// checking cert validity windows so a few seconds of issuer/Apple clock drift does
+// not reject a freshly minted attestation.
+const CERT_CLOCK_SKEW_MS = parseInt(process.env.APP_ATTEST_CLOCK_SKEW_MS || '300000', 10);
 
 // Are we fully configured to ENFORCE, or do we run as a fail-closed stub? The
 // issuer logs this at startup so stub mode is never silent.
 const APP_ATTEST_READY = Boolean(APPLE_ROOT_CA_PEM_B64 && APPLE_TEAM_ID && APPLE_BUNDLE_ID);
 
+// Apple's App Attest credCert carries the nonce in this private extension OID.
+const APPLE_NONCE_OID = '1.2.840.113635.100.8.2';
+
 // rpId for App Attest is the appID; its SHA-256 is what the authenticator data
 // binds. Computed once if we have the inputs.
+function appId() {
+  return `${APPLE_TEAM_ID}.${APPLE_BUNDLE_ID}`;
+}
 function appIdHash() {
-  const appId = `${APPLE_TEAM_ID}.${APPLE_BUNDLE_ID}`;
-  return crypto.createHash('sha256').update(appId).digest();
+  return crypto.createHash('sha256').update(appId(), 'utf8').digest();
+}
+
+// The expected 16-byte aaguid: ASCII label, zero-padded to 16 bytes.
+function expectedAaguid() {
+  const out = Buffer.alloc(16);
+  Buffer.from(EXPECTED_AAGUID_LABEL, 'ascii').copy(out, 0, 0, 16);
+  return out;
+}
+
+function sha256(...bufs) {
+  const h = crypto.createHash('sha256');
+  for (const b of bufs) h.update(b);
+  return h.digest();
 }
 
 // ---------------------------------------------------------------------------
-// The individual Apple-defined checks. Each returns true ONLY when the check
-// genuinely passes. Anything not yet implementable without operator input is a
-// STUB that returns false (fail closed) with a precise TODO.
+// Minimal CBOR decoder. App Attest attestation objects and assertions use only:
+//   - unsigned ints (major 0), negative ints (major 1, for COSE map keys),
+//   - byte strings (major 2), text strings (major 3),
+//   - arrays (major 4), maps (major 5).
+// We deliberately do NOT support tags, floats, indefinite-length, or anything
+// else; encountering them throws, which fails the validation closed. Lengths are
+// bounded by the caller's MAX_BODY, so there is no unbounded allocation here.
 // ---------------------------------------------------------------------------
 
-// CHECK 1 - Certificate chain.
-// Verify the attestation statement's x5c cert chain terminates at Apple's App
-// Attest Root CA, and that the leaf ("credCert") is valid (dates, signature).
-//
-// STUB. TODO: parse the attestation CBOR (`fmt` must be "apple-appattest",
-// `attStmt.x5c` is [credCert, intermediateCert]), build an X.509 chain, and verify
-// it against APPLE_ROOT_CA_PEM_B64 using e.g. node's crypto.X509Certificate +
-// checkIssued, or a vetted PKI lib. Per Apple step 1-2 of "Verify the attestation".
-function verifyCertChain(_attestationObj) {
-  if (!APPLE_ROOT_CA_PEM_B64) return false; // no root => cannot anchor => fail closed
-  // TODO(operator): implement X.509 chain validation to Apple's App Attest Root CA.
-  return false;
+function cborDecodeFirst(buf) {
+  const st = { buf, pos: 0 };
+  const value = cborReadItem(st, 0);
+  return { value, end: st.pos };
 }
 
-// CHECK 2 - Nonce binding.
-// Apple's nonce = SHA-256( authenticatorData || SHA-256(clientDataHash) ). It must
-// appear in the leaf cert's Apple App Attest OID extension (1.2.840.113635.100.8.2).
-// This is what binds the attestation to the exact request the device signed, so a
-// captured attestation can't be replayed against a different request.
-//
-// STUB. TODO: extract the OID 1.2.840.113635.100.8.2 octet string from credCert,
-// compute the expected nonce from authenticatorData + clientDataHash, compare.
-// Per Apple step 3-4.
-function verifyNonce(_authenticatorData, _clientDataHash, _credCert) {
-  // TODO(operator): implement nonce extraction + comparison.
-  return false;
+const CBOR_MAX_DEPTH = 16;
+
+function cborReadItem(st, depth) {
+  if (depth > CBOR_MAX_DEPTH) throw new Error('cbor: max depth exceeded');
+  if (st.pos >= st.buf.length) throw new Error('cbor: truncated');
+  const ib = st.buf[st.pos++];
+  const major = ib >> 5;
+  const minor = ib & 0x1f;
+  const len = cborReadLength(st, minor);
+  switch (major) {
+    case 0: // unsigned int
+      return len;
+    case 1: // negative int: -1 - len
+      return -1 - Number(len);
+    case 2: { // byte string
+      const n = Number(len);
+      if (st.pos + n > st.buf.length) throw new Error('cbor: byte string overruns');
+      const out = st.buf.subarray(st.pos, st.pos + n);
+      st.pos += n;
+      return Buffer.from(out);
+    }
+    case 3: { // text string
+      const n = Number(len);
+      if (st.pos + n > st.buf.length) throw new Error('cbor: text string overruns');
+      const out = st.buf.toString('utf8', st.pos, st.pos + n);
+      st.pos += n;
+      return out;
+    }
+    case 4: { // array
+      const n = Number(len);
+      const arr = new Array(n);
+      for (let i = 0; i < n; i++) arr[i] = cborReadItem(st, depth + 1);
+      return arr;
+    }
+    case 5: { // map
+      const n = Number(len);
+      const m = new Map();
+      for (let i = 0; i < n; i++) {
+        const k = cborReadItem(st, depth + 1);
+        const v = cborReadItem(st, depth + 1);
+        m.set(k, v);
+      }
+      return m;
+    }
+    default:
+      throw new Error(`cbor: unsupported major type ${major}`);
+  }
 }
 
-// CHECK 3 - Key id binding.
-// The SHA-256 of the credCert's public key must equal the keyId the device
-// presented. This ties the attestation to the specific hardware key.
-//
-// STUB. TODO: export the credCert subject public key, SHA-256 it, compare to the
-// base64url-decoded keyId. Per Apple step 5.
-function verifyKeyId(_credCert, _keyId) {
-  // TODO(operator): implement public-key-hash == keyId comparison.
-  return false;
-}
-
-// CHECK 4 - rpId (appID) hash + aaguid + counter, in the authenticator data.
-//   - authData[0..32) (rpIdHash) must equal SHA-256("<TeamID>.<BundleID>").
-//   - the aaguid field must be the expected App Attest environment value.
-//   - on first attestation the sign counter must be 0.
-//
-// STUB. TODO: parse authenticatorData (rpIdHash | flags | counter | aaguid |
-// credentialIdLength | credentialId), compare rpIdHash to appIdHash(), check
-// aaguid == EXPECTED_AAGUID, counter == 0. Per Apple step 6-9.
-function verifyAuthenticatorData(_authenticatorData, _keyId) {
-  if (!APPLE_TEAM_ID || !APPLE_BUNDLE_ID) return false; // no appID => fail closed
-  // appIdHash() is the value we WOULD compare rpIdHash against once parsed.
-  void appIdHash();
-  void EXPECTED_AAGUID;
-  // TODO(operator): implement authenticator-data parsing + comparisons.
-  return false;
-}
-
-// CHECK 5 - Assertion (subsequent calls).
-// After the one-time attestation, each request carries an ASSERTION: a signature
-// by the attested key over SHA-256(authenticatorData || clientDataHash), plus a
-// sign counter that MUST strictly increase across requests from the same key (a
-// replayed or rolled-back counter is rejected). This is the per-request proof.
-//
-// STUB. TODO: verify the assertion signature with the stored public key for keyId,
-// and enforce strictly-monotonic sign counter using a per-keyId store (the same
-// shared store the quota uses). Per Apple "Assert your app's validity".
-function verifyAssertion(_assertion, _clientDataHash, _storedPublicKeyForKeyId) {
-  // TODO(operator): implement assertion signature + monotonic counter check.
-  return false;
+function cborReadLength(st, minor) {
+  if (minor < 24) return minor;
+  if (minor === 24) { // 1 byte
+    if (st.pos + 1 > st.buf.length) throw new Error('cbor: truncated len8');
+    return st.buf[st.pos++];
+  }
+  if (minor === 25) { // 2 bytes
+    if (st.pos + 2 > st.buf.length) throw new Error('cbor: truncated len16');
+    const v = st.buf.readUInt16BE(st.pos); st.pos += 2; return v;
+  }
+  if (minor === 26) { // 4 bytes
+    if (st.pos + 4 > st.buf.length) throw new Error('cbor: truncated len32');
+    const v = st.buf.readUInt32BE(st.pos); st.pos += 4; return v;
+  }
+  if (minor === 27) { // 8 bytes
+    if (st.pos + 8 > st.buf.length) throw new Error('cbor: truncated len64');
+    const hi = st.buf.readUInt32BE(st.pos);
+    const lo = st.buf.readUInt32BE(st.pos + 4);
+    st.pos += 8;
+    // App Attest never legitimately uses 8-byte lengths; reject anything that
+    // would not fit safely in a JS number rather than silently truncate.
+    if (hi !== 0) throw new Error('cbor: length too large');
+    return lo;
+  }
+  throw new Error('cbor: indefinite or reserved length not supported');
 }
 
 // ---------------------------------------------------------------------------
-// Public entry point. Returns true ONLY if every applicable check passes. While
-// the module is in stub mode (operator inputs absent) this ALWAYS returns false,
-// so the issuer rejects every request - fail closed, never fake success.
+// Minimal ASN.1 DER walk - just enough to extract one extension's OCTET STRING by
+// OID from an X.509 certificate. We do NOT build a general ASN.1 parser; we walk
+// the TLV tree to find the matching extension. crypto.X509Certificate on node 20
+// does not expose arbitrary extensions, so this fills that one gap.
 // ---------------------------------------------------------------------------
-async function validateAppAttest({ keyId, attestation, assertion, clientDataHash } = {}) {
-  // Hard gate: refuse to even attempt verification until the operator has supplied
-  // Apple's root CA and the app identity. This is the explicit, non-silent stub.
+
+// Read one DER TLV at offset. Returns { tag, len, headerLen, contentStart }.
+function derReadTLV(buf, off) {
+  if (off + 1 > buf.length) throw new Error('der: truncated tag');
+  const tag = buf[off];
+  let p = off + 1;
+  if (p >= buf.length) throw new Error('der: truncated length');
+  let len = buf[p++];
+  if (len & 0x80) {
+    const nBytes = len & 0x7f;
+    if (nBytes === 0 || nBytes > 4) throw new Error('der: bad long-form length');
+    if (p + nBytes > buf.length) throw new Error('der: truncated long length');
+    len = 0;
+    for (let i = 0; i < nBytes; i++) len = (len << 8) | buf[p++];
+  }
+  const contentStart = p;
+  if (contentStart + len > buf.length) throw new Error('der: content overruns');
+  return { tag, len, headerLen: contentStart - off, contentStart };
+}
+
+// Encode an OID dotted string into its DER content bytes (no tag/length), so we
+// can compare against the encoded OID inside the cert without an ASN.1 library.
+function encodeOid(dotted) {
+  const parts = dotted.split('.').map((x) => parseInt(x, 10));
+  if (parts.length < 2) throw new Error('oid: too short');
+  const bytes = [40 * parts[0] + parts[1]];
+  for (let i = 2; i < parts.length; i++) {
+    let v = parts[i];
+    const stack = [v & 0x7f];
+    v >>= 7;
+    while (v > 0) { stack.unshift((v & 0x7f) | 0x80); v >>= 7; }
+    for (const b of stack) bytes.push(b);
+  }
+  return Buffer.from(bytes);
+}
+
+// Recursively scan the DER tree for an Extension SEQUENCE whose first element is
+// an OID equal to `oidBytes`, and return the bytes of its extnValue OCTET STRING.
+// An X.509 Extension is: SEQUENCE { OID, [BOOLEAN critical], OCTET STRING value }.
+function findExtensionValue(certDer, oidDotted) {
+  const oidBytes = encodeOid(oidDotted);
+  const found = { value: null };
+
+  function walk(buf, start, end, depth) {
+    if (depth > 24 || found.value) return;
+    let off = start;
+    while (off < end && !found.value) {
+      let tlv;
+      try { tlv = derReadTLV(buf, off); } catch { return; }
+      const tag = tlv.tag;
+      const cStart = tlv.contentStart;
+      const cEnd = cStart + tlv.len;
+
+      // Is THIS a SEQUENCE that begins with our target OID? (An Extension.)
+      if (tag === 0x30) {
+        try {
+          const inner = derReadTLV(buf, cStart);
+          if (inner.tag === 0x06 && inner.len === oidBytes.length &&
+              buf.subarray(inner.contentStart, inner.contentStart + inner.len).equals(oidBytes)) {
+            // Walk siblings to find the OCTET STRING (skip an optional BOOLEAN).
+            let sib = inner.contentStart + inner.len;
+            while (sib < cEnd) {
+              const s = derReadTLV(buf, sib);
+              if (s.tag === 0x04) { // OCTET STRING = extnValue
+                found.value = Buffer.from(buf.subarray(s.contentStart, s.contentStart + s.len));
+                return;
+              }
+              sib = s.contentStart + s.len;
+            }
+          }
+        } catch { /* not a matching extension; fall through to recurse */ }
+      }
+
+      // Recurse into constructed types (high bit 0x20 of the tag), and into the
+      // context-tagged [3] explicit wrapper that holds X.509 v3 extensions.
+      const constructed = (tag & 0x20) !== 0;
+      if (constructed) walk(buf, cStart, cEnd, depth + 1);
+
+      off = cEnd;
+    }
+  }
+
+  walk(certDer, 0, certDer.length, 0);
+  return found.value;
+}
+
+// The Apple nonce extension's extnValue is itself DER: an OCTET STRING wrapping
+// SEQUENCE { [1] EXPLICIT OCTET STRING nonce }. Parse out the 32-byte nonce.
+function parseAppleNonce(extnValueDer) {
+  // extnValue content is a SEQUENCE.
+  const seq = derReadTLV(extnValueDer, 0);
+  if (seq.tag !== 0x30) throw new Error('nonce: outer not SEQUENCE');
+  // First (and only) element is context-tag [1] constructed (0xA1).
+  const ctx = derReadTLV(extnValueDer, seq.contentStart);
+  if (ctx.tag !== 0xa1) throw new Error('nonce: expected [1] context tag');
+  // Inside is an OCTET STRING with the 32-byte nonce.
+  const oct = derReadTLV(extnValueDer, ctx.contentStart);
+  if (oct.tag !== 0x04) throw new Error('nonce: inner not OCTET STRING');
+  if (oct.len !== 32) throw new Error('nonce: not 32 bytes');
+  return Buffer.from(extnValueDer.subarray(oct.contentStart, oct.contentStart + oct.len));
+}
+
+// ---------------------------------------------------------------------------
+// authenticatorData parsing.
+//   rpIdHash:  32 bytes
+//   flags:      1 byte   (bit 6 = AT, attestedCredentialData present)
+//   signCount:  4 bytes  big-endian
+//   [attestedCredentialData, present iff AT flag]:
+//      aaguid:           16 bytes
+//      credIdLen:         2 bytes big-endian
+//      credentialId:      credIdLen bytes  (App Attest: the keyId)
+//      credentialPubKey:  COSE_Key (CBOR map) - the attested EC P-256 key
+// ---------------------------------------------------------------------------
+
+function parseAuthenticatorData(authData) {
+  if (!Buffer.isBuffer(authData) || authData.length < 37) {
+    throw new Error('authData: too short');
+  }
+  const rpIdHash = authData.subarray(0, 32);
+  const flags = authData[32];
+  const signCount = authData.readUInt32BE(33);
+  const out = { rpIdHash: Buffer.from(rpIdHash), flags, signCount };
+
+  const atPresent = (flags & 0x40) !== 0; // bit 6
+  if (atPresent) {
+    let off = 37;
+    if (off + 18 > authData.length) throw new Error('authData: attestedCredentialData truncated');
+    const aaguid = authData.subarray(off, off + 16); off += 16;
+    const credIdLen = authData.readUInt16BE(off); off += 2;
+    if (off + credIdLen > authData.length) throw new Error('authData: credentialId truncated');
+    const credentialId = authData.subarray(off, off + credIdLen); off += credIdLen;
+    // The remaining bytes are the COSE_Key for the credential public key.
+    const { value: coseKey } = cborDecodeFirst(Buffer.from(authData.subarray(off)));
+    out.aaguid = Buffer.from(aaguid);
+    out.credentialId = Buffer.from(credentialId);
+    out.credentialPublicKey = coseKeyToEcPublicKey(coseKey);
+    out.credentialPublicKeyRawPoint = out.credentialPublicKey.rawPoint;
+  }
+  return out;
+}
+
+// Convert a COSE_Key (CBOR map) for an EC2 / P-256 / ES256 public key into a node
+// KeyObject plus its uncompressed X9.62 point (0x04 || X || Y), which is the value
+// App Attest hashes to produce the keyId.
+function coseKeyToEcPublicKey(coseKey) {
+  if (!(coseKey instanceof Map)) throw new Error('cose: not a map');
+  const kty = coseKey.get(1);
+  const alg = coseKey.get(3);
+  const crv = coseKey.get(-1);
+  const x = coseKey.get(-2);
+  const y = coseKey.get(-3);
+  if (kty !== 2) throw new Error('cose: kty must be EC2');
+  if (alg !== -7) throw new Error('cose: alg must be ES256');
+  if (crv !== 1) throw new Error('cose: crv must be P-256');
+  if (!Buffer.isBuffer(x) || x.length !== 32) throw new Error('cose: bad x');
+  if (!Buffer.isBuffer(y) || y.length !== 32) throw new Error('cose: bad y');
+  const rawPoint = Buffer.concat([Buffer.from([0x04]), x, y]);
+  const jwk = {
+    kty: 'EC',
+    crv: 'P-256',
+    x: x.toString('base64url'),
+    y: y.toString('base64url'),
+  };
+  const keyObject = crypto.createPublicKey({ key: jwk, format: 'jwk' });
+  return { keyObject, rawPoint };
+}
+
+// ---------------------------------------------------------------------------
+// The individual Apple-defined checks. Each throws on failure (caught by the
+// caller, which then returns ok:false), so a check never quietly "passes."
+// ---------------------------------------------------------------------------
+
+// CHECK 1 - Certificate chain. Verify x5c terminates at Apple's App Attest Root
+// CA: each cert is signed by the next, the top is signed by (or equals an
+// intermediate signed by) the pinned root, and every cert is within its validity
+// window. Returns the leaf (credCert) X509Certificate.
+function verifyCertChain(x5c, now = Date.now()) {
+  if (!APPLE_ROOT_CA_PEM_B64) throw new Error('chain: no root CA configured');
+  if (!Array.isArray(x5c) || x5c.length < 1) throw new Error('chain: empty x5c');
+
+  const rootPem = Buffer.from(APPLE_ROOT_CA_PEM_B64, 'base64').toString('utf8');
+  const root = new crypto.X509Certificate(rootPem);
+
+  const certs = x5c.map((der) => {
+    if (!Buffer.isBuffer(der)) throw new Error('chain: x5c entry not bytes');
+    return new crypto.X509Certificate(der);
+  });
+
+  // Validity windows (with a small skew tolerance).
+  for (const c of [...certs, root]) {
+    const notBefore = new Date(c.validFrom).getTime();
+    const notAfter = new Date(c.validTo).getTime();
+    if (Number.isNaN(notBefore) || Number.isNaN(notAfter)) throw new Error('chain: bad validity dates');
+    if (now < notBefore - CERT_CLOCK_SKEW_MS) throw new Error('chain: cert not yet valid');
+    if (now > notAfter + CERT_CLOCK_SKEW_MS) throw new Error('chain: cert expired');
+  }
+
+  // Build the full chain to anchor: [leaf, ...intermediates, root].
+  const chain = [...certs, root];
+  for (let i = 0; i < chain.length - 1; i++) {
+    const child = chain[i];
+    const issuer = chain[i + 1];
+    // checkIssued confirms the issuer/subject name relationship.
+    if (!child.checkIssued(issuer)) throw new Error(`chain: cert ${i} not issued by next`);
+    // verify() confirms the cryptographic signature with the issuer's public key.
+    if (!child.verify(issuer.publicKey)) throw new Error(`chain: cert ${i} signature invalid`);
+  }
+  // The root must be self-signed and be the pinned Apple root (identity by its raw
+  // DER: we constructed `root` from the pinned PEM, so anchoring to it IS the pin).
+  if (!root.verify(root.publicKey)) throw new Error('chain: root not self-signed');
+
+  return certs[0]; // credCert / leaf
+}
+
+// CHECK 2 - Nonce binding. nonce = SHA-256(authData || clientDataHash). It must
+// equal the 32-byte value in the credCert's Apple OID extension. This binds the
+// attestation to the exact challenge the issuer gave the device.
+//
+// This runs ONLY after CHECK 1 has proven credCert is signed by Apple, so the
+// extension contents are authentic and cannot be forged or duplicated by an
+// attacker: the first-match search in findExtensionValue is safe because an
+// attacker cannot mint or alter extensions on an Apple-signed leaf.
+function verifyNonce(authData, clientDataHash, credCert) {
+  const expected = sha256(authData, clientDataHash);
+  const extnValue = findExtensionValue(Buffer.from(credCert.raw), APPLE_NONCE_OID);
+  if (!extnValue) throw new Error('nonce: extension missing');
+  const actual = parseAppleNonce(extnValue);
+  if (!crypto.timingSafeEqual(expected, actual)) throw new Error('nonce: mismatch');
+  return true;
+}
+
+// CHECK 3 - Key id binding. keyId = SHA-256(uncompressed EC public key point) of
+// the credCert key MUST equal the keyId the device presented (and the credentialId
+// inside authData). This ties the attestation to the specific hardware key.
+function verifyKeyId(credCert, presentedKeyId, credentialPublicKeyRawPoint, credentialId) {
+  // Extract the leaf cert's public key as an uncompressed P-256 point.
+  const certJwk = credCert.publicKey.export({ format: 'jwk' });
+  if (certJwk.kty !== 'EC' || certJwk.crv !== 'P-256') throw new Error('keyId: leaf key not P-256');
+  const certPoint = Buffer.concat([
+    Buffer.from([0x04]),
+    Buffer.from(certJwk.x, 'base64url'),
+    Buffer.from(certJwk.y, 'base64url'),
+  ]);
+  // The credential public key in authData must be the SAME key as the cert's.
+  if (!certPoint.equals(credentialPublicKeyRawPoint)) {
+    throw new Error('keyId: cert key != authData credential key');
+  }
+  const computed = sha256(certPoint);
+
+  // presentedKeyId is base64url (App Attest keyId is base64-encoded SHA-256).
+  const presented = decodeKeyId(presentedKeyId);
+  if (presented.length !== 32 || !crypto.timingSafeEqual(computed, presented)) {
+    throw new Error('keyId: presented keyId != SHA256(pubkey)');
+  }
+  // The credentialId inside authData is the same keyId.
+  if (!Buffer.isBuffer(credentialId) || credentialId.length !== 32 ||
+      !crypto.timingSafeEqual(computed, credentialId)) {
+    throw new Error('keyId: credentialId != SHA256(pubkey)');
+  }
+  return computed; // the canonical keyId (raw 32 bytes)
+}
+
+// Accept the keyId in base64 or base64url; both decode to the same 32 bytes.
+function decodeKeyId(keyId) {
+  if (typeof keyId !== 'string' || keyId.length === 0) throw new Error('keyId: missing');
+  const b = Buffer.from(keyId, 'base64'); // base64 decode also tolerates base64url chars in node
+  return b;
+}
+
+// CHECK 4 - authenticator data: rpIdHash, aaguid, and first-attestation counter.
+function verifyAttestationAuthData(parsed) {
+  if (!crypto.timingSafeEqual(parsed.rpIdHash, appIdHash())) {
+    throw new Error('authData: rpIdHash != SHA256(appID)');
+  }
+  if ((parsed.flags & 0x40) === 0) throw new Error('authData: AT flag not set');
+  if (!parsed.aaguid || !parsed.aaguid.equals(expectedAaguid())) {
+    throw new Error('authData: aaguid mismatch');
+  }
+  if (parsed.signCount !== 0) throw new Error('authData: first attestation signCount must be 0');
+  return true;
+}
+
+// CHECK 5 - Assertion (subsequent calls). Verify the ECDSA-P256-SHA256 signature
+// by the attested key over SHA-256(authenticatorData || clientDataHash), the
+// rpIdHash, and a strictly increasing sign counter. Returns the new sign counter
+// so the caller can persist it.
+function verifyAssertion(assertionBuf, clientDataHash, storedPublicKeyObject, storedCounter) {
+  const { value: assertion } = cborDecodeFirst(assertionBuf);
+  if (!(assertion instanceof Map)) throw new Error('assertion: not a CBOR map');
+  const signature = assertion.get('signature');
+  const authData = assertion.get('authenticatorData');
+  if (!Buffer.isBuffer(signature) || !Buffer.isBuffer(authData)) {
+    throw new Error('assertion: missing signature/authenticatorData');
+  }
+
+  // The signed bytes: SHA-256(authData || SHA-256(challenge)).
+  const nonce = sha256(authData, clientDataHash);
+
+  // ECDSA over SHA-256; the signature is DER-encoded (X9.62). node verifies DER
+  // by default for createVerify('SHA256') on an EC key.
+  const ok = crypto.verify('sha256', nonce, storedPublicKeyObject, signature);
+  if (!ok) throw new Error('assertion: bad signature');
+
+  const parsed = parseAuthenticatorData(authData);
+  if (!crypto.timingSafeEqual(parsed.rpIdHash, appIdHash())) {
+    throw new Error('assertion: rpIdHash != SHA256(appID)');
+  }
+  // Strictly increasing counter: a replayed or rolled-back counter is rejected.
+  if (!(parsed.signCount > storedCounter)) {
+    throw new Error('assertion: signCount not strictly increasing');
+  }
+  return parsed.signCount;
+}
+
+// ---------------------------------------------------------------------------
+// CBOR attestation object decode -> { fmt, x5c, authData }.
+// ---------------------------------------------------------------------------
+function decodeAttestation(attestationBuf) {
+  const { value } = cborDecodeFirst(attestationBuf);
+  if (!(value instanceof Map)) throw new Error('attestation: not a CBOR map');
+  const fmt = value.get('fmt');
+  const attStmt = value.get('attStmt');
+  const authData = value.get('authData');
+  if (fmt !== 'apple-appattest') throw new Error('attestation: fmt must be apple-appattest');
+  if (!(attStmt instanceof Map)) throw new Error('attestation: attStmt missing');
+  const x5c = attStmt.get('x5c');
+  if (!Array.isArray(x5c) || x5c.length < 1) throw new Error('attestation: x5c missing');
+  if (!Buffer.isBuffer(authData)) throw new Error('attestation: authData missing');
+  return { fmt, x5c, authData };
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point.
+//
+// ATTESTATION (one-time registration): pass { keyId, attestation, clientDataHash }.
+//   On success returns { ok: true, mode: 'attestation', keyId (base64),
+//   publicKeyPem, signCount } so the caller persists the device public key keyed
+//   by keyId for future assertions.
+//
+// ASSERTION (per issuance): pass { keyId, assertion, clientDataHash } and a
+//   `store` with getAttestedKey(keyId) / setSignCount(keyId, n). On success
+//   returns { ok: true, mode: 'assertion', signCount }.
+//
+// Returns { ok: false, reason } on any failure. While the module is unconfigured
+// (operator inputs absent) this ALWAYS returns { ok: false } - fail closed.
+// ---------------------------------------------------------------------------
+async function validateAppAttest({ keyId, attestation, assertion, clientDataHash, store } = {}) {
   if (!APP_ATTEST_READY) {
-    return false;
+    return { ok: false, reason: 'app_attest_not_configured' };
+  }
+  if (typeof clientDataHash !== 'string' || !clientDataHash.length) {
+    return { ok: false, reason: 'missing_client_data_hash' };
+  }
+  let clientDataHashBuf;
+  try {
+    clientDataHashBuf = Buffer.from(clientDataHash, 'base64');
+    if (clientDataHashBuf.length !== 32) {
+      return { ok: false, reason: 'client_data_hash_not_32_bytes' };
+    }
+  } catch {
+    return { ok: false, reason: 'bad_client_data_hash' };
   }
 
-  // clientDataHash binds the attestation/assertion to the request the device made.
-  // Required in both flows.
-  if (typeof clientDataHash !== 'string' || !clientDataHash.length) return false;
-  const clientDataHashBuf = Buffer.from(clientDataHash, 'base64');
+  try {
+    // First contact for a device: full attestation.
+    if (attestation) {
+      const attestationBuf = Buffer.from(attestation, 'base64');
+      const { x5c, authData } = decodeAttestation(attestationBuf);
 
-  // First contact for a device: full attestation. Later: lightweight assertion.
-  if (attestation) {
-    const attestationObj = decodeAttestation(attestation);
-    if (!attestationObj) return false;
-    const { authenticatorData, credCert } = attestationObj;
-    if (!verifyCertChain(attestationObj)) return false;
-    if (!verifyNonce(authenticatorData, clientDataHashBuf, credCert)) return false;
-    if (!verifyKeyId(credCert, keyId)) return false;
-    if (!verifyAuthenticatorData(authenticatorData, keyId)) return false;
-    // On success an operator implementation persists the attested public key for
-    // this keyId so future assertions can be checked. (Shared store, see server.js.)
-    return true;
+      const credCert = verifyCertChain(x5c);                        // CHECK 1
+      verifyNonce(authData, clientDataHashBuf, credCert);           // CHECK 2
+      const parsed = parseAuthenticatorData(authData);
+      const canonicalKeyId = verifyKeyId(                           // CHECK 3
+        credCert,
+        keyId,
+        parsed.credentialPublicKeyRawPoint,
+        parsed.credentialId,
+      );
+      verifyAttestationAuthData(parsed);                            // CHECK 4
+
+      // Hand back the attested public key so the caller can store it keyed by
+      // keyId. We return a PEM (SPKI) so the store is a plain serializable string.
+      const publicKeyPem = parsed.credentialPublicKey.keyObject.export({
+        type: 'spki',
+        format: 'pem',
+      });
+      const keyIdB64 = canonicalKeyId.toString('base64');
+
+      // Cross-check the canonical keyId equals the one presented (already enforced
+      // in CHECK 3, but make the returned identity unambiguous).
+      return {
+        ok: true,
+        mode: 'attestation',
+        keyId: keyIdB64,
+        publicKeyPem,
+        signCount: parsed.signCount, // 0
+      };
+    }
+
+    // Subsequent calls: lightweight assertion against the stored key.
+    if (assertion) {
+      if (!store || typeof store.getAttestedKey !== 'function' ||
+          typeof store.setSignCount !== 'function') {
+        return { ok: false, reason: 'no_attested_key_store' };
+      }
+      // Normalize the keyId the SAME way the attestation path stored it (canonical
+      // base64), so a base64 vs base64url spelling difference between the
+      // registration and a later assertion can't cause a spurious store miss.
+      const storeKeyId = decodeKeyId(keyId).toString('base64');
+      const record = store.getAttestedKey(storeKeyId);
+      if (!record || !record.publicKeyPem) {
+        return { ok: false, reason: 'unknown_device_key' };
+      }
+      const pub = crypto.createPublicKey({ key: record.publicKeyPem, format: 'pem' });
+      const assertionBuf = Buffer.from(assertion, 'base64');
+      const newCount = verifyAssertion(                            // CHECK 5
+        assertionBuf,
+        clientDataHashBuf,
+        pub,
+        record.signCount || 0,
+      );
+      store.setSignCount(storeKeyId, newCount);
+      return { ok: true, mode: 'assertion', signCount: newCount };
+    }
+
+    return { ok: false, reason: 'no_attestation_or_assertion' };
+  } catch (err) {
+    // Any thrown check fails the whole validation closed. We deliberately surface
+    // only a coarse reason string, never the attestation/assertion bytes.
+    return { ok: false, reason: 'verification_failed', detail: err && err.message };
   }
-
-  if (assertion) {
-    const storedPub = lookupAttestedKey(keyId); // STUB lookup, see below
-    if (!storedPub) return false;
-    if (!verifyAssertion(assertion, clientDataHashBuf, storedPub)) return false;
-    return true;
-  }
-
-  // Neither attestation nor assertion present => nothing to verify => reject.
-  return false;
-}
-
-// Decode the CBOR attestation object into { fmt, authenticatorData, credCert, ... }.
-//
-// STUB. TODO: CBOR-decode the base64 attestation (a vetted CBOR lib), pull out
-// `authData` and `attStmt.x5c`. Returns null in stub mode so callers fail closed.
-function decodeAttestation(_attestationB64) {
-  // TODO(operator): CBOR-decode the App Attest attestation object.
-  return null;
-}
-
-// Look up the previously-attested public key for a keyId (populated on the first
-// successful attestation). STUB. TODO: read from the shared store (the same one
-// the quota/redemption state uses). Returns null in stub mode => fail closed.
-function lookupAttestedKey(_keyId) {
-  // TODO(operator): read attested public key for keyId from the shared store.
-  return null;
 }
 
 export {
   validateAppAttest,
   APP_ATTEST_READY,
-  // Exported for tests/operators wiring real implementations in.
+  // Exported for tests / operators wiring real implementations in.
+  appId,
   appIdHash,
+  expectedAaguid,
   verifyCertChain,
   verifyNonce,
   verifyKeyId,
-  verifyAuthenticatorData,
+  verifyAttestationAuthData,
   verifyAssertion,
+  parseAuthenticatorData,
+  decodeAttestation,
+  cborDecodeFirst,
+  findExtensionValue,
+  parseAppleNonce,
+  encodeOid,
 };

--- a/token-issuer/appattest.test.js
+++ b/token-issuer/appattest.test.js
@@ -1,0 +1,366 @@
+// Columbia - Apple App Attest validation tests.
+//
+// Run: node --test   (from this directory)
+//
+// We have NO real device attestation in CI, so these tests mint a SYNTHETIC trust
+// chain + attestation (see appattest-fixtures.js) that satisfies every Apple check, and
+// then prove:
+//   (a) GOLDEN PATH: a well-formed attestation is ACCEPTED, the device public key
+//       and keyId are returned, and a following assertion verifies.
+//   (b) NEGATIVE: each single tampered field is REJECTED on its own -
+//       wrong rpIdHash, wrong nonce/challenge, broken chain, untrusted root,
+//       wrong aaguid, non-zero first counter, wrong/forged keyId, bad assertion
+//       signature, non-increasing assertion counter, unknown device key.
+//   (c) FAIL-CLOSED: missing inputs are rejected, and with App Attest unconfigured
+//       the validator rejects everything.
+//
+// IMPORTANT: appattest.js reads its operator config (root CA, team, bundle, aaguid)
+// from env AT MODULE LOAD. So this file sets that env to the synthetic fixture's
+// root BEFORE importing appattest.js. The trust anchor is the only substitution;
+// every cryptographic and structural check is the real one.
+
+import test from 'node:test';
+import assert from 'node:assert';
+import crypto from 'node:crypto';
+
+import {
+  makeAttestationFixture, makeAssertion, newP256, buildCert,
+  buildAttestationAuthData, appleNonceExtension,
+  cborMap, cborArray, cborBytes, cborText, uncompressedPoint,
+} from './appattest-fixtures.js';
+
+// --- One canonical fixture drives the env config for the whole file ----------
+
+const APP_ID = 'PRWUVMURYJ.com.wbs.lander';
+const TEAM_ID = 'PRWUVMURYJ';
+const BUNDLE_ID = 'com.wbs.lander';
+
+// Build the baseline (valid) fixture first so we can pin its root CA via env.
+const baseChallenge = crypto.randomBytes(32);
+const base = makeAttestationFixture({ appId: APP_ID, aaguidLabel: 'appattest', challenge: baseChallenge });
+
+process.env.APPLE_APP_ATTEST_ROOT_CA_PEM_B64 = base.rootPemB64;
+process.env.APPLE_TEAM_ID = TEAM_ID;
+process.env.APPLE_BUNDLE_ID = BUNDLE_ID;
+process.env.APPLE_APP_ATTEST_AAGUID = 'appattest';
+
+// Now import the validator (it reads the env above at load).
+const appattest = await import('./appattest.js');
+const { validateAppAttest, APP_ATTEST_READY } = appattest;
+
+// A tiny in-memory attested-key store, as server.js would provide.
+function makeStore() {
+  const m = new Map();
+  return {
+    map: m,
+    getAttestedKey(keyId) { return m.get(keyId) || null; },
+    setSignCount(keyId, n) { const r = m.get(keyId); if (r) r.signCount = n; },
+    register(keyId, publicKeyPem, signCount = 0) { m.set(keyId, { publicKeyPem, signCount }); },
+  };
+}
+
+// ===========================================================================
+// (a) GOLDEN PATH
+// ===========================================================================
+
+test('module is configured (APP_ATTEST_READY) for these tests', () => {
+  assert.strictEqual(APP_ATTEST_READY, true, 'env must configure App Attest for the suite');
+});
+
+test('(a1) a well-formed attestation is ACCEPTED and returns the device key + keyId', async () => {
+  const res = await validateAppAttest({
+    keyId: base.keyIdB64,
+    attestation: base.attestationB64,
+    clientDataHash: base.clientDataHashB64,
+  });
+  assert.strictEqual(res.ok, true, `attestation must be accepted: ${res.reason} ${res.detail || ''}`);
+  assert.strictEqual(res.mode, 'attestation');
+  assert.strictEqual(res.signCount, 0, 'first attestation counter is 0');
+  assert.strictEqual(res.keyId, base.keyIdB64, 'returns the same keyId the device presented');
+  assert.match(res.publicKeyPem, /BEGIN PUBLIC KEY/, 'returns the attested public key as PEM');
+});
+
+test('(a2) an assertion from the attested key verifies and advances the counter', async () => {
+  const reg = await validateAppAttest({
+    keyId: base.keyIdB64, attestation: base.attestationB64, clientDataHash: base.clientDataHashB64,
+  });
+  assert.strictEqual(reg.ok, true);
+
+  const store = makeStore();
+  store.register(base.keyIdB64, reg.publicKeyPem, reg.signCount);
+
+  const a = makeAssertion({ appId: APP_ID, credPrivateKey: base.credKey.privateKey, signCount: 7, challenge: crypto.randomBytes(32) });
+  const res = await validateAppAttest({ keyId: base.keyIdB64, assertion: a.assertionB64, clientDataHash: a.clientDataHashB64, store });
+  assert.strictEqual(res.ok, true, `assertion must verify: ${res.reason} ${res.detail || ''}`);
+  assert.strictEqual(res.mode, 'assertion');
+  assert.strictEqual(res.signCount, 7);
+  assert.strictEqual(store.getAttestedKey(base.keyIdB64).signCount, 7, 'counter persisted');
+});
+
+test('(a3) two assertions with strictly increasing counters both pass', async () => {
+  const reg = await validateAppAttest({ keyId: base.keyIdB64, attestation: base.attestationB64, clientDataHash: base.clientDataHashB64 });
+  const store = makeStore();
+  store.register(base.keyIdB64, reg.publicKeyPem, 0);
+
+  const a1 = makeAssertion({ appId: APP_ID, credPrivateKey: base.credKey.privateKey, signCount: 3, challenge: crypto.randomBytes(32) });
+  const r1 = await validateAppAttest({ keyId: base.keyIdB64, assertion: a1.assertionB64, clientDataHash: a1.clientDataHashB64, store });
+  assert.strictEqual(r1.ok, true);
+
+  const a2 = makeAssertion({ appId: APP_ID, credPrivateKey: base.credKey.privateKey, signCount: 4, challenge: crypto.randomBytes(32) });
+  const r2 = await validateAppAttest({ keyId: base.keyIdB64, assertion: a2.assertionB64, clientDataHash: a2.clientDataHashB64, store });
+  assert.strictEqual(r2.ok, true);
+  assert.strictEqual(store.getAttestedKey(base.keyIdB64).signCount, 4);
+});
+
+// ===========================================================================
+// (b) NEGATIVE - each single tampered field is rejected on its own
+// ===========================================================================
+
+test('(b1) wrong rpIdHash (attestation for a different appID) is REJECTED', async () => {
+  // A fixture built for a DIFFERENT appID has a different rpIdHash in authData, but
+  // is otherwise well-formed. Anchor it to the pinned root by reusing base's root:
+  // simplest is to mint under base's root key directly.
+  const wrong = makeAttestationFixtureUnderRoot({
+    rootKey: base.rootKey, interKey: base.interKey,
+    appId: 'PRWUVMURYJ.com.wbs.WRONG', aaguidLabel: 'appattest', challenge: crypto.randomBytes(32),
+  });
+  const res = await validateAppAttest({ keyId: wrong.keyIdB64, attestation: wrong.attestationB64, clientDataHash: wrong.clientDataHashB64 });
+  assert.strictEqual(res.ok, false);
+  assert.match(res.detail || '', /rpIdHash/, 'must fail on rpIdHash mismatch');
+});
+
+test('(b2) wrong challenge (nonce mismatch) is REJECTED', async () => {
+  // Present the valid attestation but with a clientDataHash for a DIFFERENT
+  // challenge. The nonce baked into the cert no longer matches.
+  const otherChallenge = crypto.randomBytes(32);
+  const otherCdh = crypto.createHash('sha256').update(otherChallenge).digest().toString('base64');
+  const res = await validateAppAttest({ keyId: base.keyIdB64, attestation: base.attestationB64, clientDataHash: otherCdh });
+  assert.strictEqual(res.ok, false);
+  assert.match(res.detail || '', /nonce/, 'must fail on nonce mismatch');
+});
+
+test('(b3) broken chain (leaf re-signed by a stranger key) is REJECTED', async () => {
+  // Re-sign the leaf with a random key that is NOT the intermediate, so the chain
+  // signature breaks while names still line up.
+  const stranger = newP256();
+  const fx = makeAttestationFixtureUnderRoot({
+    rootKey: base.rootKey, interKey: base.interKey,
+    appId: APP_ID, aaguidLabel: 'appattest', challenge: crypto.randomBytes(32),
+    leafSignerOverride: stranger.privateKey,
+  });
+  const res = await validateAppAttest({ keyId: fx.keyIdB64, attestation: fx.attestationB64, clientDataHash: fx.clientDataHashB64 });
+  assert.strictEqual(res.ok, false);
+  assert.match(res.detail || '', /chain/, 'must fail on chain signature');
+});
+
+test('(b4) untrusted root (chain that does not anchor to the pinned root) is REJECTED', async () => {
+  // A completely fresh fixture mints its OWN root, which is NOT the pinned one.
+  const fresh = makeAttestationFixture({ appId: APP_ID, aaguidLabel: 'appattest', challenge: crypto.randomBytes(32) });
+  const res = await validateAppAttest({ keyId: fresh.keyIdB64, attestation: fresh.attestationB64, clientDataHash: fresh.clientDataHashB64 });
+  assert.strictEqual(res.ok, false);
+  assert.match(res.detail || '', /chain/, 'must fail to anchor to the pinned root');
+});
+
+test('(b5) wrong AAGUID (dev aaguid while prod is expected) is REJECTED', async () => {
+  const devFx = makeAttestationFixtureUnderRoot({
+    rootKey: base.rootKey, interKey: base.interKey,
+    appId: APP_ID, aaguidLabel: 'appattestdevelop', challenge: crypto.randomBytes(32),
+  });
+  const res = await validateAppAttest({ keyId: devFx.keyIdB64, attestation: devFx.attestationB64, clientDataHash: devFx.clientDataHashB64 });
+  assert.strictEqual(res.ok, false);
+  assert.match(res.detail || '', /aaguid/, 'a dev aaguid must be rejected when prod is configured');
+});
+
+test('(b6) non-zero first-attestation counter is REJECTED', async () => {
+  const fx = makeAttestationFixtureUnderRoot({
+    rootKey: base.rootKey, interKey: base.interKey,
+    appId: APP_ID, aaguidLabel: 'appattest', challenge: crypto.randomBytes(32),
+    signCount: 1,
+  });
+  const res = await validateAppAttest({ keyId: fx.keyIdB64, attestation: fx.attestationB64, clientDataHash: fx.clientDataHashB64 });
+  assert.strictEqual(res.ok, false);
+  assert.match(res.detail || '', /signCount/, 'first attestation must have counter 0');
+});
+
+test('(b7) wrong keyId (does not match SHA256 of the attested key) is REJECTED', async () => {
+  const bogusKeyId = crypto.randomBytes(32).toString('base64');
+  const res = await validateAppAttest({ keyId: bogusKeyId, attestation: base.attestationB64, clientDataHash: base.clientDataHashB64 });
+  assert.strictEqual(res.ok, false);
+  assert.match(res.detail || '', /keyId/, 'a keyId that is not SHA256(pubkey) must be rejected');
+});
+
+test('(b8) bad assertion signature (signed by the WRONG key) is REJECTED', async () => {
+  const reg = await validateAppAttest({ keyId: base.keyIdB64, attestation: base.attestationB64, clientDataHash: base.clientDataHashB64 });
+  const store = makeStore();
+  store.register(base.keyIdB64, reg.publicKeyPem, 0);
+
+  // Sign the assertion with a DIFFERENT key than the one registered.
+  const attacker = newP256();
+  const a = makeAssertion({ appId: APP_ID, credPrivateKey: attacker.privateKey, signCount: 9, challenge: crypto.randomBytes(32) });
+  const res = await validateAppAttest({ keyId: base.keyIdB64, assertion: a.assertionB64, clientDataHash: a.clientDataHashB64, store });
+  assert.strictEqual(res.ok, false);
+  assert.match(res.detail || '', /signature/, 'an assertion signed by the wrong key must be rejected');
+});
+
+test('(b9) assertion with a non-increasing counter (replay/rollback) is REJECTED', async () => {
+  const reg = await validateAppAttest({ keyId: base.keyIdB64, attestation: base.attestationB64, clientDataHash: base.clientDataHashB64 });
+  const store = makeStore();
+  store.register(base.keyIdB64, reg.publicKeyPem, 10); // already at 10
+
+  const a = makeAssertion({ appId: APP_ID, credPrivateKey: base.credKey.privateKey, signCount: 10, challenge: crypto.randomBytes(32) });
+  const res = await validateAppAttest({ keyId: base.keyIdB64, assertion: a.assertionB64, clientDataHash: a.clientDataHashB64, store });
+  assert.strictEqual(res.ok, false);
+  assert.match(res.detail || '', /signCount/, 'a non-increasing counter must be rejected');
+});
+
+test('(b10) assertion with a tampered authenticatorData byte is REJECTED', async () => {
+  const reg = await validateAppAttest({ keyId: base.keyIdB64, attestation: base.attestationB64, clientDataHash: base.clientDataHashB64 });
+  const store = makeStore();
+  store.register(base.keyIdB64, reg.publicKeyPem, 0);
+
+  const a = makeAssertion({ appId: APP_ID, credPrivateKey: base.credKey.privateKey, signCount: 2, challenge: crypto.randomBytes(32) });
+  // Flip a byte in the signed authData by re-encoding a tampered CBOR map.
+  const tampered = Buffer.from(a.assertionB64, 'base64');
+  tampered[tampered.length - 1] ^= 0xff; // corrupt the last authData byte
+  const res = await validateAppAttest({ keyId: base.keyIdB64, assertion: tampered.toString('base64'), clientDataHash: a.clientDataHashB64, store });
+  assert.strictEqual(res.ok, false, 'a tampered authData must not verify');
+});
+
+test('(b11) assertion for an unknown device key is REJECTED', async () => {
+  const store = makeStore(); // empty store
+  const a = makeAssertion({ appId: APP_ID, credPrivateKey: base.credKey.privateKey, signCount: 1, challenge: crypto.randomBytes(32) });
+  const res = await validateAppAttest({ keyId: base.keyIdB64, assertion: a.assertionB64, clientDataHash: a.clientDataHashB64, store });
+  assert.strictEqual(res.ok, false);
+  assert.strictEqual(res.reason, 'unknown_device_key');
+});
+
+test('(b12) ATTACKER-SUPPLIED ROOT in x5c is REJECTED (anchor-pinning bypass)', async () => {
+  // The classic App Attest server bug: a validator that "anchors" by appending the
+  // trusted root to the PRESENTED chain without checking the presented chain
+  // actually connects to it. Here the attacker builds a fully self-consistent
+  // chain - their own self-signed root, their own intermediate, a leaf carrying the
+  // CORRECT nonce/keyId/rpIdHash/aaguid - and even APPENDS their own root cert into
+  // x5c. It must still be rejected, because the terminal presented cert is not
+  // signed by the PINNED Apple root.
+  const challenge = crypto.randomBytes(32);
+  const appId = APP_ID;
+  const rpIdHash = crypto.createHash('sha256').update(appId, 'utf8').digest();
+  const clientDataHash = crypto.createHash('sha256').update(challenge).digest();
+
+  const attackerRoot = newP256();
+  const attackerInter = newP256();
+  const credKey = newP256();
+  const credPoint = uncompressedPoint(credKey.publicKey);
+  const keyIdRaw = crypto.createHash('sha256').update(credPoint).digest();
+
+  const authData = buildAttestationAuthData({ rpIdHash, aaguidLabel: 'appattest', credentialId: keyIdRaw, credentialKey: credKey.publicKey });
+  const nonce = crypto.createHash('sha256').update(authData).update(clientDataHash).digest();
+
+  const attackerRootDer = buildCert({
+    subjectCN: 'Evil Root', issuerCN: 'Evil Root',
+    subjectKey: attackerRoot.publicKey, issuerKey: attackerRoot.privateKey, serial: 1,
+  });
+  const attackerInterDer = buildCert({
+    subjectCN: 'Evil CA', issuerCN: 'Evil Root',
+    subjectKey: attackerInter.publicKey, issuerKey: attackerRoot.privateKey, serial: 2,
+  });
+  const leafDer = buildCert({
+    subjectCN: 'Evil Credential', issuerCN: 'Evil CA',
+    subjectKey: credKey.publicKey, issuerKey: attackerInter.privateKey, serial: 3,
+    extensions: [appleNonceExtension(nonce)],
+  });
+
+  // x5c includes the attacker's OWN root as the terminal cert.
+  const attObj = cborMap([
+    [cborText('fmt'), cborText('apple-appattest')],
+    [cborText('attStmt'), cborMap([[cborText('x5c'), cborArray([cborBytes(leafDer), cborBytes(attackerInterDer), cborBytes(attackerRootDer)])]])],
+    [cborText('authData'), cborBytes(authData)],
+  ]);
+
+  const res = await validateAppAttest({
+    keyId: keyIdRaw.toString('base64'),
+    attestation: attObj.toString('base64'),
+    clientDataHash: clientDataHash.toString('base64'),
+  });
+  assert.strictEqual(res.ok, false, 'an attacker-rooted chain must NOT anchor to the pinned Apple root');
+  assert.match(res.detail || '', /chain/, 'must fail at the chain-anchoring step');
+});
+
+// ===========================================================================
+// (c) FAIL-CLOSED - missing/garbage inputs
+// ===========================================================================
+
+test('(c1) missing clientDataHash is REJECTED', async () => {
+  const res = await validateAppAttest({ keyId: base.keyIdB64, attestation: base.attestationB64 });
+  assert.strictEqual(res.ok, false);
+  assert.strictEqual(res.reason, 'missing_client_data_hash');
+});
+
+test('(c2) a clientDataHash that is not 32 bytes is REJECTED', async () => {
+  const res = await validateAppAttest({ keyId: base.keyIdB64, attestation: base.attestationB64, clientDataHash: Buffer.from('short').toString('base64') });
+  assert.strictEqual(res.ok, false);
+  assert.strictEqual(res.reason, 'client_data_hash_not_32_bytes');
+});
+
+test('(c3) neither attestation nor assertion is REJECTED', async () => {
+  const res = await validateAppAttest({ keyId: base.keyIdB64, clientDataHash: base.clientDataHashB64 });
+  assert.strictEqual(res.ok, false);
+  assert.strictEqual(res.reason, 'no_attestation_or_assertion');
+});
+
+test('(c4) garbage CBOR attestation is REJECTED (parser fails closed, no crash)', async () => {
+  const res = await validateAppAttest({ keyId: base.keyIdB64, attestation: Buffer.from('not cbor at all $$$').toString('base64'), clientDataHash: base.clientDataHashB64 });
+  assert.strictEqual(res.ok, false);
+});
+
+test('(c5) assertion without a store is REJECTED', async () => {
+  const a = makeAssertion({ appId: APP_ID, credPrivateKey: base.credKey.privateKey, signCount: 1, challenge: crypto.randomBytes(32) });
+  const res = await validateAppAttest({ keyId: base.keyIdB64, assertion: a.assertionB64, clientDataHash: a.clientDataHashB64 });
+  assert.strictEqual(res.ok, false);
+  assert.strictEqual(res.reason, 'no_attested_key_store');
+});
+
+// ===========================================================================
+// Helper: mint a fixture under a GIVEN root + intermediate key, with optional
+// tampers, so negative tests can vary ONE field while still anchoring to the
+// pinned root. This mirrors appattest-fixtures.makeAttestationFixture but lets the
+// caller pass the existing root/intermediate and tweak appId/aaguid/counter/leaf
+// signer. Kept here (not in appattest-fixtures) because it is purely a test concern.
+// ===========================================================================
+
+function makeAttestationFixtureUnderRoot({ rootKey, interKey, appId, aaguidLabel, challenge, signCount = 0, leafSignerOverride = null }) {
+  const rpIdHash = crypto.createHash('sha256').update(appId, 'utf8').digest();
+  const clientDataHash = crypto.createHash('sha256').update(challenge).digest();
+
+  const credKey = newP256();
+  const credPoint = uncompressedPoint(credKey.publicKey);
+  const keyIdRaw = crypto.createHash('sha256').update(credPoint).digest();
+  const credentialId = keyIdRaw;
+
+  const authData = buildAttestationAuthData({ rpIdHash, aaguidLabel, credentialId, credentialKey: credKey.publicKey, signCount });
+  const nonce = crypto.createHash('sha256').update(authData).update(clientDataHash).digest();
+
+  const interDer = buildCert({
+    subjectCN: 'Columbia Test App Attestation CA 1', issuerCN: 'Columbia Test App Attest Root CA',
+    subjectKey: interKey.publicKey, issuerKey: rootKey.privateKey, serial: 100,
+  });
+  const leafDer = buildCert({
+    subjectCN: 'Columbia Test App Attest Credential', issuerCN: 'Columbia Test App Attestation CA 1',
+    subjectKey: credKey.publicKey,
+    issuerKey: leafSignerOverride || interKey.privateKey, // override = broken chain
+    serial: 2, extensions: [appleNonceExtension(nonce)],
+  });
+
+  const attObj = cborMap([
+    [cborText('fmt'), cborText('apple-appattest')],
+    [cborText('attStmt'), cborMap([[cborText('x5c'), cborArray([cborBytes(leafDer), cborBytes(interDer)])]])],
+    [cborText('authData'), cborBytes(authData)],
+  ]);
+
+  return {
+    keyIdB64: keyIdRaw.toString('base64'),
+    attestationB64: attObj.toString('base64'),
+    clientDataHashB64: clientDataHash.toString('base64'),
+    credKey,
+  };
+}

--- a/token-issuer/server.js
+++ b/token-issuer/server.js
@@ -61,6 +61,12 @@ const MAX_TOKENS_PER_REQUEST = parseInt(process.env.MAX_TOKENS_PER_REQUEST || '6
 // Body size cap (the assertion + N blinded messages). Bounds memory per request.
 const MAX_BODY = parseInt(process.env.MAX_BODY_BYTES || '262144', 10);
 
+// Bind the App Attest clientDataHash to the blinded[] payload (see handleIssue
+// step a2). ON by default: App Attest then proves the device authorized THESE
+// tokens, not just that a genuine device is present. Set to 0 only during client
+// bring-up, before the iOS client computes clientDataHash over the batch.
+const REQUIRE_CLIENT_DATA_BINDING = process.env.REQUIRE_CLIENT_DATA_BINDING !== '0';
+
 // The issuer signing key (PKCS#8, base64-encoded) is injected at runtime via env,
 // exactly like the gateway's SEED_SECRET_KEY. It is NEVER committed. If unset, the
 // issuer fails closed at startup. To rotate per epoch in production you supply the
@@ -89,6 +95,23 @@ function log(fields) {
 // only the epoch's key id, so spend time leaks nothing finer than the epoch.
 function currentEpoch() {
   return Math.floor(Date.now() / 1000 / EPOCH_SECONDS);
+}
+
+// The canonical value the device's App Attest challenge must hash to, so the
+// attestation/assertion is bound to THIS blinded batch in THIS epoch (see the
+// REQUIRE_CLIENT_DATA_BINDING gate in handleIssue). The client computes the same
+// SHA-256 over the same bytes when it requests its App Attest assertion:
+//   SHA-256( utf8(epoch) || 0x00 || blinded[0] || 0x00 || blinded[1] || 0x00 ... )
+// where each blinded[i] is the raw (base64-decoded) blinded message. The 0x00
+// separators and the leading epoch make the preimage unambiguous.
+function expectedClientDataHash(epochId, blinded) {
+  const h = crypto.createHash('sha256');
+  h.update(String(epochId), 'utf8');
+  for (const b of blinded) {
+    h.update(Buffer.from([0x00]));
+    h.update(Buffer.from(b, 'base64'));
+  }
+  return h.digest();
 }
 
 // --- Epoch key management ---------------------------------------------------
@@ -224,6 +247,66 @@ function reserveQuota(epochId, deviceId, n) {
   return true;
 }
 
+// --- Attested-key store (App Attest device registration) --------------------
+//
+// App Attest is two-phase: a one-time ATTESTATION registers a hardware key, and
+// every later request carries an ASSERTION signed by that key. To check an
+// assertion we must remember the device's public key and its last sign counter,
+// keyed by the App Attest keyId.
+//
+// ATTESTED-KEY STORE (production): this Map is in-process and resets on restart,
+// which has the same two multi-replica gaps the quota store has: a device
+// registered on replica A is unknown to replica B, and a restart forgets every
+// registration (forcing devices to re-attest, which the Lander client handles by
+// falling back to a fresh attestation when an assertion is rejected as unknown).
+// For a real multi-replica deployment, move this to the SAME shared store as the
+// quota/redemption state (e.g. Redis: a hash per keyId holding the SPKI PEM + last
+// counter, with the counter updated via a compare-and-set so two concurrent
+// assertions cannot both pass with the same counter). The stored public key is
+// device-PUBLIC material, not a secret, but the keyId is a device identifier, so
+// key the store by a SALTED hash of the keyId exactly like the quota table rather
+// than the raw keyId. The counter update MUST be atomic to preserve the
+// strictly-increasing guarantee under concurrency.
+//
+// NOTE on identity: the keyId is the one device identifier this service handles.
+// It is used transiently to look up the attested key and is NEVER logged (see the
+// RED-only logging note at the top of this file).
+
+const attestedKeys = new Map(); // keyId -> { publicKeyPem, signCount }
+
+const ATTEST_STORE = {
+  getAttestedKey(keyId) {
+    return attestedKeys.get(keyId) || null;
+  },
+  setAttestedKey(keyId, publicKeyPem, signCount) {
+    // Re-attestation of an EXISTING keyId must not roll the assertion counter
+    // backwards: a fresh attestation reports signCount 0, but if this device has
+    // already advanced its counter via assertions, resetting to 0 would re-open the
+    // assertion-replay window for that key. Producing a fresh attestation needs
+    // genuine hardware re-attesting its own key (a valid chain-to-Apple + a
+    // challenge-bound nonce), so this is not a forgery vector, but we still keep the
+    // higher counter as defense-in-depth. The public key is identical across
+    // attestations of the same hardware key, so refreshing the PEM is harmless.
+    const existing = attestedKeys.get(keyId);
+    const keptCount = Math.max(signCount || 0, existing ? (existing.signCount || 0) : 0);
+    attestedKeys.set(keyId, { publicKeyPem, signCount: keptCount });
+    // Bound the map so a flood of one-time attestations cannot grow it forever.
+    // This is a coarse cap; the production shared store would use a TTL instead.
+    if (attestedKeys.size > 500000) {
+      // Drop the oldest ~10% by insertion order (Map preserves it).
+      let toDrop = Math.floor(attestedKeys.size * 0.1);
+      for (const k of attestedKeys.keys()) {
+        if (toDrop-- <= 0) break;
+        attestedKeys.delete(k);
+      }
+    }
+  },
+  setSignCount(keyId, n) {
+    const rec = attestedKeys.get(keyId);
+    if (rec) rec.signCount = n;
+  },
+};
+
 // --- /issue -----------------------------------------------------------------
 //
 // Request JSON:
@@ -270,22 +353,69 @@ async function handleIssue(req, res, start, body) {
   }
 
   // (a) Validate App Attest. This proves the request comes from a genuine,
-  // unmodified Lander install on real Apple hardware. FAILS CLOSED: if the
-  // validator is a stub (Apple root cert / team+bundle id not supplied), it
-  // returns false and we reject. We never log the assertion/attestation.
-  let attestOk = false;
+  // unmodified Lander install on real Apple hardware. FAILS CLOSED: if App Attest
+  // is unconfigured (Apple root cert / team+bundle id not supplied), the validator
+  // returns { ok: false } and we reject. We never log the assertion/attestation,
+  // and we never log the coarse failure reason at a level that could fingerprint a
+  // device (it is an aggregate counter only).
+  //
+  // We pass the in-process attested-key store so an ASSERTION can be checked
+  // against the device public key recorded at ATTESTATION time, and so the sign
+  // counter advances. On a successful attestation we persist the returned public
+  // key keyed by keyId.
+  let attest;
   try {
-    attestOk = await validateAppAttest({ keyId, attestation, assertion, clientDataHash });
+    attest = await validateAppAttest({ keyId, attestation, assertion, clientDataHash, store: ATTEST_STORE });
   } catch {
-    attestOk = false;
+    attest = { ok: false, reason: 'verification_exception' };
   }
-  if (!attestOk) {
+  if (!attest || !attest.ok) {
     res.writeHead(401); res.end();
     log({ route: '/issue', status: 401, reason: 'attest_failed', durationMs: Date.now() - start });
     return;
   }
+  // Register the device's attested public key on the one-time attestation, so its
+  // later assertions can be verified. (validateAppAttest does the assertion-side
+  // counter update through the store itself.)
+  if (attest.mode === 'attestation') {
+    ATTEST_STORE.setAttestedKey(attest.keyId, attest.publicKeyPem, attest.signCount);
+  }
 
+  // (a2) REQUEST-PAYLOAD BINDING. App Attest proves "a genuine device signed THIS
+  // clientDataHash"; on its own it does NOT prove the device authorized THESE
+  // blinded messages, because clientDataHash is an opaque 32 bytes from the client.
+  // Without binding, a captured valid {keyId, assertion, clientDataHash} could be
+  // replayed against a different `blinded[]` batch (still rate-limited by the
+  // per-device quota, but not request-integrity-checked).
+  //
+  // To close that, the client MUST set its App Attest challenge so that
+  //   clientDataHash == SHA-256( utf8("<epoch>") || 0x00 || each base64(blinded) joined by 0x00 )
+  // i.e. clientDataHash commits to the exact batch being requested in this epoch.
+  // We recompute that here and require equality. This is gated behind an env flag
+  // (default ON in production once the client ships the matching hash; an operator
+  // may set REQUIRE_CLIENT_DATA_BINDING=0 during client bring-up, accepting that
+  // App Attest then only bounds abuse per-device and does not bind the payload).
   const epochId = currentEpoch();
+
+  if (REQUIRE_CLIENT_DATA_BINDING) {
+    let got;
+    try { got = Buffer.from(clientDataHash, 'base64'); } catch { got = Buffer.alloc(0); }
+    // Accept the current OR previous epoch's binding: the client computes the hash
+    // against the epoch it last saw, which can be one behind the issuer if the
+    // request crosses an epoch boundary (the issuer already publishes both epochs'
+    // keys for the same reason). Both candidate hashes are constant-time compared.
+    let bound = false;
+    if (got.length === 32) {
+      for (const e of [epochId, epochId - 1]) {
+        if (crypto.timingSafeEqual(got, expectedClientDataHash(e, blinded))) { bound = true; break; }
+      }
+    }
+    if (!bound) {
+      res.writeHead(401); res.end();
+      log({ route: '/issue', status: 401, reason: 'client_data_binding_failed', durationMs: Date.now() - start });
+      return;
+    }
+  }
 
   // (b) Enforce the per-device per-epoch issuance quota. The keyId is the device
   // identifier; it is hashed before it touches the quota table and never logged.
@@ -472,6 +602,8 @@ export {
   reserveQuota,
   keyIdFromSpki,
   derivePublicKey,
+  expectedClientDataHash,
+  ATTEST_STORE,
   EPOCH_SECONDS,
   RSA_MODULUS_BITS,
   PSS_HASH,

--- a/token-issuer/test.js
+++ b/token-issuer/test.js
@@ -301,3 +301,60 @@ test('(g) boots under the entrypoint and serves a public key from a PKCS#1 signi
     child.kill('SIGKILL');
   }
 });
+
+// --- (h) App Attest clientDataHash <-> blinded[] binding --------------------
+//
+// The issuer binds the App Attest clientDataHash to the exact blinded batch and
+// epoch (REQUIRE_CLIENT_DATA_BINDING). This proves the device authorized THESE
+// tokens, not just that a genuine device is present. Assert the binding hash is
+// deterministic, order-sensitive, payload-sensitive, and epoch-sensitive, so a
+// captured assertion cannot be replayed against a different batch.
+test('(h) expectedClientDataHash binds the blinded batch + epoch', () => {
+  const { expectedClientDataHash } = issuer;
+  const epoch = 12345;
+  const a = Buffer.from('aaaa', 'utf8').toString('base64');
+  const b = Buffer.from('bbbb', 'utf8').toString('base64');
+
+  const h1 = expectedClientDataHash(epoch, [a, b]);
+  assert.strictEqual(h1.length, 32, 'binding hash is SHA-256');
+
+  // Deterministic for the same inputs.
+  assert.ok(h1.equals(expectedClientDataHash(epoch, [a, b])), 'same inputs -> same hash');
+
+  // Order-sensitive: swapping the batch order changes the binding.
+  assert.ok(!h1.equals(expectedClientDataHash(epoch, [b, a])), 'order changes the hash');
+
+  // Payload-sensitive: a different blinded message changes the binding (this is
+  // what stops replay against a different batch).
+  const c = Buffer.from('cccc', 'utf8').toString('base64');
+  assert.ok(!h1.equals(expectedClientDataHash(epoch, [a, c])), 'different payload -> different hash');
+
+  // Epoch-sensitive: the same batch in a different epoch binds differently.
+  assert.ok(!h1.equals(expectedClientDataHash(epoch + 1, [a, b])), 'different epoch -> different hash');
+
+  // The 0x00 separators make the preimage unambiguous: [ab] and [a,b] differ.
+  const ab = Buffer.from('aaaabbbb', 'utf8').toString('base64');
+  assert.ok(!expectedClientDataHash(epoch, [ab]).equals(expectedClientDataHash(epoch, [a, b])),
+    'concatenated single message must not collide with two messages');
+});
+
+// --- (i) re-attestation must not roll the assertion counter backwards --------
+//
+// A fresh attestation reports signCount 0. If a device re-attests an existing
+// keyId, the store must KEEP the higher counter so the assertion-replay window is
+// not re-opened (security review F2).
+test('(i) ATTEST_STORE preserves the higher sign counter on re-attestation', () => {
+  const { ATTEST_STORE } = issuer;
+  const keyId = 'test-keyid-' + crypto.randomBytes(8).toString('hex');
+  const pem = '-----BEGIN PUBLIC KEY-----\nMOCK\n-----END PUBLIC KEY-----\n';
+
+  // Register, then advance the counter via assertions.
+  ATTEST_STORE.setAttestedKey(keyId, pem, 0);
+  ATTEST_STORE.setSignCount(keyId, 42);
+  assert.strictEqual(ATTEST_STORE.getAttestedKey(keyId).signCount, 42);
+
+  // Re-attestation reports 0; the store must keep 42, not roll back.
+  ATTEST_STORE.setAttestedKey(keyId, pem, 0);
+  assert.strictEqual(ATTEST_STORE.getAttestedKey(keyId).signCount, 42,
+    're-attestation must not reset the counter to 0');
+});


### PR DESCRIPTION
## What this does

Replaces the fail-closed App Attest **stub** in `token-issuer/appattest.js` with the **real** server-side verification, per Apple's "Validating Apps That Connect to Your Server through App Attest." The issuer now genuinely proves an `/issue` request comes from a real, unmodified Lander install on Apple hardware before it blind-signs any tokens, instead of rejecting everything.

This is the security gate the whole Privacy Pass design rests on: without it, anyone can mint tokens and abuse the relay.

## Fully implemented

**Attestation (one-time device registration)** in `appattest.js`:
- CBOR-decode the attestation object (`fmt == "apple-appattest"`, `attStmt.x5c`, `authData`) with a small **bounded, purpose-built CBOR decoder** (no new dependency).
- Verify the `x5c` chain anchors to **Apple's App Attest Root CA** via a real X.509 path check (`crypto.X509Certificate` `verify` + `checkIssued` + validity windows). The pinned root is the *cryptographic* anchor: the terminal presented cert must be signed by it, so an attacker-supplied root in `x5c` is rejected (this is the classic App Attest server bug, and it is closed and tested).
- Verify the nonce in the leaf cert extension OID `1.2.840.113635.100.8.2` equals `SHA256(authData || clientDataHash)`, via a minimal ASN.1 DER walk.
- Verify `rpIdHash == SHA256(appID)`, the AAGUID matches the environment (`appattest` prod / `appattestdevelop` dev), and `signCount == 0`.
- Bind `keyId == SHA256(uncompressed EC point)` of the leaf key, and require it to equal the `authData` `credentialId` and the COSE credential public key. Return the device public key + keyId for storage.

**Assertion (per issuance):** verify the ECDSA-P256-SHA256 signature over `SHA256(authData || clientDataHash)` with the **stored** device key, re-check `rpIdHash`, and enforce a **strictly increasing** sign counter.

**`server.js` wiring:** an in-process attested-key store (device pubkey + last counter per keyId), the structured validator result wired into `/issue`, the key persisted on attestation, and **request-payload binding** (`REQUIRE_CLIENT_DATA_BINDING`, default on) so a captured assertion can't be replayed against a different `blinded[]` batch.

The whole module stays **fail-closed**: unconfigured (no Apple root / team / bundle) it rejects every request, and any failed check rejects the request. No silent-allow path.

## Dependency footprint

**Zero new dependencies.** CBOR decoding and the single-extension ASN.1 walk are small bounded parsers in-file (App Attest uses a tiny CBOR subset); all cryptographic work uses node's built-in `crypto` (`X509Certificate`, `verify`, `createHash`, `createPublicKey`). `package.json` / `package-lock.json` are untouched. Rationale: the safe, dependency-light part is *structural parsing*; we never hand-roll a crypto primitive.

## Still needs a real-device fixture (follow-up)

There is no real device attestation in CI, so the tests use a **synthetic** trust chain (a self-minted CA + leaf, built in pure JS in `appattest-fixtures.js`) that satisfies every Apple check. The only substitution is the trust anchor (our test root in place of Apple's, injected exactly as an operator injects the real root); every cryptographic and structural check is the production one, and the implementation is verified to parse Apple's **real** Root CA.

Before relying on this in production, capture **one** real attestation + assertion from a physical iPhone running Lander and assert `validateAppAttest` returns `ok: true` against Apple's real Root CA. Two ways, documented in `token-issuer/README.md`:
1. A short-lived debug capture endpoint on a non-prod instance (then remove it).
2. A committed captured fixture (safe to commit: a real attestation is not user-linking once the challenge is discarded). **Preferred** as a permanent regression.

Also still in-memory / single-replica (marked in code + README, unchanged scope): the quota, redemption, and attested-key stores want a shared atomic store (Redis) for multi-replica.

The **client half of request-payload binding** (the iOS app computing `clientDataHash` over the blinded batch) lives in the Lander app and is the matching follow-up there; run with `REQUIRE_CLIENT_DATA_BINDING=0` until that ships.

## Security review

An independent adversarial review found **no attestation bypass**. It confirmed the chain anchoring three ways (self-signed leaf, differently-named attacker root, identically-named attacker root: all rejected), and that the CBOR/DER parsers fail closed, `timingSafeEqual` misuse fails closed, the assertion key comes only from the store, and the keyId triple-binding cannot be made to disagree. Its one actionable finding (clientDataHash not bound to the payload) is addressed by `REQUIRE_CLIENT_DATA_BINDING`; two low-severity hardening notes (re-attestation counter reset, first-OID-match) are also addressed.

## Tests (node 20)

Run under the **deploy runtime** (`node:20.18.1-alpine`), not a newer local node, since a node-version mismatch crash-looped this service once before:

```
docker run --rm -v "$PWD":/repo -w /repo/token-issuer node:20.18.1-alpine \
  sh -c 'npm ci && npm test'
```

**30/30 pass under node v20.18.1:**
- 21 App Attest tests: golden path accepted (attestation + assertion + monotonic counter), each tampered field rejected on its own (wrong rpIdHash, wrong challenge/nonce, broken chain, untrusted root, **attacker-supplied root in x5c**, wrong aaguid, non-zero first counter, forged keyId, bad assertion signature, non-increasing counter, unknown device key), fail-closed on missing/garbage inputs.
- 7 existing Privacy Pass / boot tests (unchanged, still green).
- 2 new server tests: the clientDataHash↔blinded binding (order/payload/epoch sensitive) and re-attestation counter preservation.

Also verified end-to-end in the production Docker image: container boots cleanly (no ESM load crash), reports `appAttest: enforced` with config / `stub-fail-closed` without, `/issue` returns 401 (fail-closed) on a bogus attestation against Apple's real Root CA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLihriHmupL2kvLbcUEin7
