### PR TITLE
Front Door origin lock, security policy, and objective docs revision

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,6 +30,8 @@ flowchart LR
 | Gateway | decapsulates the request, fetches an allowlisted target, re-encapsulates | request content, never the client IP |
 | Commons cache (optional) | fetches each public item once, serves many | public content only, no user identity |
 
+The token issuer sits off this request path. It gates who may use the relay by issuing anonymous tokens the relay verifies, never touching the request itself; see [Anonymous client tokens](#anonymous-client-tokens).
+
 The transport is [OHTTP (RFC 9458)](https://www.rfc-editor.org/rfc/rfc9458). The client HPKE-seals each request against the gateway's public key (`message/ohttp-req`), the relay forwards the sealed bytes on without revealing the client, the gateway decrypts to the inner [Binary HTTP (RFC 9292)](https://www.rfc-editor.org/rfc/rfc9292) (`message/bhttp`) request, fetches the target, and returns the HPKE-sealed response (`message/ohttp-res`). The crypto is HPKE ([RFC 9180](https://www.rfc-editor.org/rfc/rfc9180)). The gateway publishes two key configs: a primary config using KEM `X25519+Kyber768-draft00` (KEM id `0x30`), a draft, non-RFC, post-quantum hybrid of X25519 and Kyber768 (treat it as experimental), and a legacy config using `DHKEM(X25519, HKDF-SHA256)` (KEM id `0x20`), the classical RFC 9180 suite. Both pair the KEM with `HKDF-SHA256` and `AES-128-GCM`. The gateway is Cloudflare's `privacy-gateway-server-go` (vendored, BSD-3). A classical-only RFC 9458 client interoperates by selecting the legacy config (KEM `0x20`); the primary config is a draft post-quantum suite that not every client supports.
 
 ### Abuse controls
@@ -38,13 +40,30 @@ The relay is the public surface, so it carries the abuse controls. The design co
 
 - A per-IP fixed-window rate limit plus a global in-flight concurrency cap, both env-tunable. The per-IP key is the address the trusted ingress terminates: behind a managed ingress the TCP peer is the ingress, so the relay reads the rightmost `X-Forwarded-For` entry. That IP is the same one the relay already terminates and is allowed to see; using it as a transient counter key reveals nothing the relay did not already hold, and it is never written to a log or forwarded to the gateway. Over-limit requests get a 429. A bounded key table keeps a spoofed-source flood from growing memory.
 - A strict request shape: only `POST /relay` with `Content-Type: message/ohttp-req` is served (wrong type returns 415, any other path or method returns 404), so there is no general proxy surface to probe.
-- A pluggable client-auth hook with three modes: off (network controls only), an interim shared-secret header checked in constant time, and a future token mode for App Attest plus blind-signed Privacy Pass tokens once a separate issuer exists. The shared-secret mode is an extractable speed-bump, not real client authentication; the credential is never logged.
+- A pluggable client-auth hook with three modes: `off` (network controls only), `secret` (a shared-secret header checked in constant time), and `token` (an anonymous issuer-signed token verified offline). The shared-secret mode is an extractable speed-bump, not real client authentication. The token mode is the real client gate, backed by the token issuer below. The credential is never logged in any mode.
 
-A relay→gateway shared secret runs alongside these. The relay attaches a constant `X-Columbia-Relay-Auth` header to its outbound request, and the gateway rejects `/gateway` traffic that lacks a matching value (constant-time, before any HPKE work). Being constant across all requests, it identifies the relay, never a client, so it leaks nothing about who is on the other end.
+A relay-to-gateway shared secret runs alongside these. The relay attaches a constant `X-Columbia-Relay-Auth` header to its outbound request, and the gateway rejects `/gateway` traffic that lacks a matching value (constant-time, before any HPKE work). Being constant across all requests, it identifies the relay, never a client, so it leaks nothing about who is on the other end.
 
 ### Single public surface
 
-The hardened deployment makes the relay the only publicly reachable component and runs the gateway and the commons cache on internal ingress, reachable only from inside the environment. With the gateway internal, clients can no longer fetch its `GET /ohttp-configs` to pin the public key config, so the relay proxies that one read-only endpoint: it returns the gateway's key-config bytes verbatim, cached briefly. The key config is public material clients are meant to pin, so this passthrough adds no surface that could leak identity. This posture sits on top of the two-operator non-collusion split, not in place of it: each operator still runs its own component, and the gateway is simply no longer exposed to the open internet. [SELFHOSTING.md](./SELFHOSTING.md#single-public-surface-internal-gateway-and-commons) covers the deployment details.
+The relay is the only publicly reachable component. The gateway and the commons cache run on internal ingress, reachable only from inside the environment, and the token issuer is its own public service alongside the relay. With the gateway internal, clients cannot fetch its `GET /ohttp-configs` to pin the public key config, so the relay proxies that one read-only endpoint: it returns the gateway's key-config bytes verbatim, cached briefly. The key config is public material clients are meant to pin, so this passthrough adds no surface that could leak identity. This posture sits on top of the two-operator non-collusion split, not in place of it: each operator still runs its own component, and the gateway stays off the open internet. [SELFHOSTING.md](./SELFHOSTING.md#single-public-surface-internal-gateway-and-commons) covers the deployment details.
+
+### Edge front door
+
+A CDN or WAF can sit in front of the public relay and issuer to absorb DDoS and rate-limit per IP at the edge before traffic reaches the origins. When the relay and issuer are configured to require it, they reject any request that did not arrive through that front door, verified through a front-door identifier the front door injects into a header. This pins each public origin to the front door so its host cannot be hit directly. The check is inert unless an operator enables it, and the identifier is never logged. Health probes are exempt so the platform can still reach the origins in-environment, and the issuer's `GET /issuer-keys` is exempt because the relay fetches it directly. A managed front door is one way to run this; any CDN or WAF that injects a verifiable origin-lock header works. See [SELFHOSTING.md](./SELFHOSTING.md#edge-front-door-cdn--waf).
+
+## Anonymous client tokens
+
+`token` mode answers a question the network controls cannot: let only a genuine, rate-limited client use the relay, without that gate becoming a way to identify the client. The token issuer is a separate service that plays the Attester and Issuer roles of the Privacy Pass architecture ([RFC 9576](https://www.rfc-editor.org/rfc/rfc9576)).
+
+- The device proves it is genuine Apple hardware running an unmodified install with App Attest. The issuer is the one component allowed to see the device identity at issuance time.
+- The device blinds its token inputs locally and sends only the blinded messages. The issuer blind-signs each with the current epoch RSA private key ([RFC 9474](https://www.rfc-editor.org/rfc/rfc9474), `RSABSSA-SHA384-PSS`, the Apple Private Access Token construction from [RFC 9578](https://www.rfc-editor.org/rfc/rfc9578)) and returns blind signatures. It never unblinds, so it never sees a finished token.
+- A per-device per-epoch quota bounds issuance, so even a genuine device is rate limited.
+- The device finalizes each token locally, then spends one per relay request in the outer OHTTP header. The relay verifies the signature offline against the issuer's published epoch public key and enforces spend-once. It fetches that public key once and caches it, so there is no per-request call to the issuer and the issuer never learns which token was spent.
+
+The blind signature severs the device identity the issuer saw at issuance from the token the relay sees at spend time. The unblinding factor never leaves the device, so even if one operator ran both the issuer and the relay, it could not match a token back to the device that requested it from a single request. Keep them under separate non-colluding operators anyway: with enough traffic shaping, an operator that holds both views could begin to correlate issuance and spend timing across many requests. The keypair rotates per epoch (one week by default), so everyone issued in the same epoch is one anonymity set, and the quota counter and spend-once set both self-expire when the epoch rolls.
+
+The exact wire format, the App Attest binding, and the epoch model are in [`token-issuer/PROTOCOL.md`](./token-issuer/PROTOCOL.md).
 
 ## Trust and threat model
 
@@ -56,9 +75,10 @@ The design keeps identity and content with two separate parties, so neither one 
 | Relay | yes | no | only ever holds `message/ohttp-req` ciphertext, can't decrypt |
 | Gateway | no | yes | the relay sends a fresh request with no client IP or headers; the gateway holds the HPKE seed |
 | Commons cache | no | public content only | sits behind the gateway, serves identical public content to everyone |
+| Token issuer | sees the device id at issuance | no | only blinded token requests; never the finished token, never the content it is spent on |
 | Upstream | sees the gateway's IP | yes | never sees your IP, sees one shared fetcher |
 
-No single party ever holds identity and content at the same time. The relay has identity without content, the gateway has content without identity.
+No single party ever holds identity and content at the same time. The relay has identity without content, the gateway has content without identity, and the issuer sees a device identity but only blinded material it cannot tie to any spent token.
 
 ### Non-collusion
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Columbia is named after Apollo 11's Command and Service Module, the ship that stayed up in orbit while the lander went down, with no view of what happened on the surface.
 
-It's a small toolkit with almost no dependencies. You point it at HTTP content and fetch through a split-trust path built on OHTTP ([RFC 9458](https://www.rfc-editor.org/rfc/rfc9458)). There are three pieces, each a separate service you run yourself, on plain Docker, on whatever host you want.
+It's a small toolkit with almost no dependencies. You point it at HTTP content and fetch through a split-trust path built on OHTTP ([RFC 9458](https://www.rfc-editor.org/rfc/rfc9458)). Three services carry the request path (relay, gateway, commons cache), and a fourth optional service (the token issuer) gates who may use the relay without identifying them. Each is a service you run yourself, on plain Docker, on whatever host you want.
 
 The property that matters is this: no single operator ever holds your identity and your content at the same time. The relay sees your IP but only opaque ciphertext. The gateway decrypts and fetches but never sees your IP. Run those two as separate operators and neither one can connect you to what you read.
 
@@ -49,7 +49,7 @@ The full trust and threat model, the attestation chain, and the observability de
 
 - Fetching your own HTTP reads through a split-trust path, so neither hop can tie your network identity to what you asked for.
 - Caching public content without being able to see who read it. Put the commons cache in front of public, sessionless endpoints (listings, feeds, public APIs) and many reads collapse into a handful of upstream fetches.
-- A starting point for building operator-blind transports into your own apps. The pieces are small, they stick to published standards (RFC 9458, 9292, 9180), and they're short enough to read end to end.
+- A starting point for building operator-blind transports into your own apps. The pieces are small, they stick to published standards (RFC 9458, 9292, 9180 for the transport; RFC 9576, 9474, 9578 for the anonymous tokens), and they're short enough to read end to end.
 
 Columbia is a read-path privacy layer, nothing more. It carries public, sessionless reads only. Authenticated and write requests are out of scope by design, not by limitation: your client makes those directly over its own session, so they never touch shared infrastructure at all, which is the more private place for them to run anyway. It is not a VPN, and it never pools or shares credentials.
 
@@ -62,10 +62,27 @@ Columbia is a read-path privacy layer, nothing more. It carries public, sessionl
 | [`ohttp-relay/`](./ohttp-relay) | Strips your IP and all headers, forwards opaque ciphertext to the gateway | your IP plus opaque bytes, never content |
 | [`ohttp-gateway/`](./ohttp-gateway) | Decapsulates the request, fetches the allowlisted target, re-encapsulates the response | request content, never your IP |
 | [`commons-cache/`](./commons-cache) | Fetches each public item once and serves all; TTL plus stale-while-revalidate plus single-flight | public content only, no user identity |
+| [`token-issuer/`](./token-issuer) | App Attest gated, blind-signs anonymous unlinkable tokens the relay verifies offline | the device id at issuance, never the spent token or your content |
 
-- `ohttp-relay/` is a Node service with no dependencies. It forwards `message/ohttp-req` bodies to the gateway in a fresh request that carries no client headers and no `X-Forwarded-For`. As the one public surface it also carries the abuse controls (per-IP rate limiting, a concurrency cap, a strict request shape, and a pluggable client-auth hook), all keeping ephemeral state that is never logged. For the hardened topology it can run as the sole public hop, with the gateway and cache on internal ingress, and pass the gateway's public key config through to clients. See [SELFHOSTING.md](./SELFHOSTING.md). Its logs are RED metrics only.
-- `ohttp-gateway/` is a vendored copy of Cloudflare's [`privacy-gateway-server-go`](https://github.com/cloudflare/privacy-gateway-server-go) (BSD-3, the RFC 9458 reference gateway). The source is unmodified; everything it does is configured at runtime through environment variables. Provenance and the required attribution live in [`ohttp-gateway/VENDORED.md`](./ohttp-gateway/VENDORED.md).
+- `ohttp-relay/` is a Node service with no dependencies. It forwards `message/ohttp-req` bodies to the gateway in a fresh request that carries no client headers and no `X-Forwarded-For`. As the public surface it carries the abuse controls described below. Its logs are RED metrics only.
+- `ohttp-gateway/` is a vendored copy of Cloudflare's [`privacy-gateway-server-go`](https://github.com/cloudflare/privacy-gateway-server-go) (BSD-3, the RFC 9458 reference gateway). The source is unmodified apart from two small env-gated access controls; everything else it does is configured at runtime through environment variables. Provenance and the required attribution live in [`ohttp-gateway/VENDORED.md`](./ohttp-gateway/VENDORED.md).
 - `commons-cache/` is another dependency-free Node service, an optional cache origin for public, sessionless content. It serves `X-Cache: HIT|MISS|STALE` with CDN-ready `Cache-Control` and `Age` headers.
+- `token-issuer/` is its own service. It runs Apple App Attest verification and blind-signs ([RFC 9474](https://www.rfc-editor.org/rfc/rfc9474)) anonymous tokens so the relay can require a genuine, rate-limited client without a login. It is the one component that learns a device identity, and the blinding makes that knowledge useless: it never sees the finished tokens or the content they are spent on. Verifying a spent token at the relay is offline against the issuer's published epoch public key. See [`token-issuer/PROTOCOL.md`](./token-issuer/PROTOCOL.md) for the wire format and [`token-issuer/README.md`](./token-issuer).
+
+---
+
+## Public surface and abuse controls
+
+The relay is the only service that has to be public. The gateway and the commons cache run on internal ingress, reachable only from inside the environment, and the issuer is its own public service alongside the relay. Because the gateway is internal, clients cannot fetch its key config directly, so the relay proxies that one read at `GET /ohttp-configs` and returns the gateway's public key-config bytes verbatim. That is public material clients are meant to pin, so the passthrough leaks nothing.
+
+The relay carries the abuse controls, none of which weaken the operator-blind property because all of their state is in memory, keyed to nothing that ties back to content, and never logged:
+
+- Per-IP rate limiting keyed on the address the trusted ingress appended, plus a global concurrency cap.
+- A strict request shape: only `POST /relay` with `Content-Type: message/ohttp-req` is served.
+- A relay-to-gateway shared secret (`X-Columbia-Relay-Auth`) so the gateway rejects traffic that did not come through the relay.
+- A pluggable client-auth hook with modes `off`, `secret`, and `token`. In `token` mode the relay verifies an anonymous issuer-signed token offline and enforces spend-once.
+
+A CDN or WAF (for example a managed front door) can sit in front of the public relay and issuer to absorb DDoS and rate-limit at the edge. When the relay and issuer are configured to require it, they reject any request that did not arrive through that front door, so the origins cannot be reached directly. See [SELFHOSTING.md](./SELFHOSTING.md).
 
 ---
 
@@ -138,6 +155,7 @@ flowchart TD
     roadmap["ROADMAP.md: hardening / decentralization direction"]
     license["LICENSE: PolyForm Noncommercial 1.0.0"]
     gitignore[".gitignore"]
+    security["SECURITY.md: reporting + the guarantee in scope"]
     commons["commons-cache/: optional public-content cache origin (Node)"]
     commonsfiles["server.js, Dockerfile, deploy-ghcr.sh, README.md"]
     gateway["ohttp-gateway/: VENDORED Cloudflare OHTTP gateway (Go, BSD-3)"]
@@ -145,12 +163,15 @@ flowchart TD
     gatewaysrc["… (unmodified upstream source + vendored Go deps)"]
     relay["ohttp-relay/: OHTTP relay (Node)"]
     relayfiles["server.js, Dockerfile, README.md"]
+    issuer["token-issuer/: App Attest + blind-RSA token issuer (Node)"]
+    issuerfiles["server.js, appattest.js, PROTOCOL.md, Dockerfile, README.md"]
 
     root --> readme
     root --> arch
     root --> self
     root --> roadmap
     root --> license
+    root --> security
     root --> gitignore
     root --> commons
     commons --> commonsfiles
@@ -159,6 +180,8 @@ flowchart TD
     gateway --> gatewaysrc
     root --> relay
     relay --> relayfiles
+    root --> issuer
+    issuer --> issuerfiles
 ```
 
 ## Standards
@@ -168,6 +191,9 @@ flowchart TD
 | [RFC 9458](https://www.rfc-editor.org/rfc/rfc9458) | OHTTP, the relay/gateway split-trust transport |
 | [RFC 9292](https://www.rfc-editor.org/rfc/rfc9292) | Binary HTTP, the inner `message/bhttp` request/response |
 | [RFC 9180](https://www.rfc-editor.org/rfc/rfc9180) | HPKE. The gateway publishes two key configs (see note below). |
+| [RFC 9576](https://www.rfc-editor.org/rfc/rfc9576) | Privacy Pass architecture, the issuer's Attester and Issuer roles |
+| [RFC 9474](https://www.rfc-editor.org/rfc/rfc9474) | Blind RSA (`RSABSSA-SHA384-PSS`), the token blind-signature suite |
+| [RFC 9578](https://www.rfc-editor.org/rfc/rfc9578) | Privacy Pass Token Type 2, the Apple Private Access Token construction the issuer mints |
 
 The gateway publishes two HPKE key configs:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Columbia is privacy infrastructure. A flaw here can deanonymize users, so please
+report security issues privately rather than in a public issue. Open a private
+security advisory on this repository (Security, then Advisories, then Report a
+vulnerability), or contact the maintainer directly.
+
+Include what you found, how to reproduce it, and the impact. You can expect an
+acknowledgement within a few days.
+
+## The guarantee in scope
+
+The core property is operator-blindness. The relay sees the client address but
+not the request content. The gateway sees the content but not the client
+address. Neither hop holds both. The highest-priority reports are the ones that
+break this split: anything that lets one hop learn what the other sees, that
+leaks a client identifier into a log or a response, or that links a client to
+the content they fetched.
+
+## Known limitations that are not vulnerabilities
+
+The non-collusion assumption is documented, not a bug. If a single operator runs
+both the relay and the gateway, that operator can line up the address it saw at
+the relay against the content it decrypted at the gateway. The protection holds
+only when the two hops are run by separate parties who do not collude, or when
+you run the whole thing yourself. See README.md and ARCHITECTURE.md. A
+single-operator deployment correlating its own hops is out of scope.

--- a/SELFHOSTING.md
+++ b/SELFHOSTING.md
@@ -1,6 +1,6 @@
 # Self-Hosting Columbia
 
-This guide gets the three components (relay, gateway, and optionally the commons cache) running on plain Docker, on any host. You don't need a managed cloud. There's one optional cloud example at the end, with placeholders you swap for your own resource names.
+This guide gets the request-path components (relay, gateway, and optionally the commons cache) running on plain Docker, on any host, plus the optional token issuer that gates who may use the relay. You don't need a managed cloud. There's one optional cloud example at the end, with placeholders you swap for your own resource names.
 
 > Read this first. The operator-blind guarantee only holds when the relay and gateway are run by different operators who don't collude. Running both on one host is fine for testing, but it gives you no protection against that single operator. The [two-operator section](#running-relay-and-gateway-as-separate-operators) below explains how to split them for the real guarantee.
 
@@ -98,22 +98,30 @@ docker run -d --name relay --network columbia -p 8081:8080 \
 |---|---|---|
 | `GATEWAY_URL` | yes | full gateway endpoint, e.g. `https://<gateway-host>/gateway` (must be `https`) |
 | `PORT` | `8080` | listen port |
+| `MAX_BODY_BYTES` | `65536` | cap on the inbound ciphertext body buffered per request |
+| `MAX_RESP_BYTES` | `1000000` | cap on the gateway response buffered per request |
+| `GW_TIMEOUT_MS` | `15000` | timeout on the relay-to-gateway request |
 | `RATE_LIMIT_RPM` | `120` | per-IP requests per minute; `0` disables per-IP limiting |
 | `RATE_WINDOW_MS` | `60000` | length of the fixed rate-limit window |
 | `MAX_INFLIGHT` | `256` | global cap on concurrent relays; further requests get a 429 |
 | `RATE_MAX_KEYS` | `100000` | hard cap on tracked IP keys, so a spoofed-source flood can't grow the table unbounded |
-| `CLIENT_AUTH_MODE` | `off` | client auth: `off`, `secret` (shared-secret header), or `token` (future) |
+| `CLIENT_AUTH_MODE` | `off` | client auth: `off`, `secret` (shared-secret header), or `token` (anonymous issuer token) |
 | `CLIENT_SECRET` | (none) | shared secret required when `CLIENT_AUTH_MODE=secret` |
-| `CLIENT_AUTH_HEADER` | `authorization` | header the client presents its credential in |
+| `CLIENT_AUTH_HEADER` | `x-lander-token` | header the client presents its credential in (both `secret` and `token` modes read it) |
+| `ISSUER_KEYS_URL` | (none) | in `token` mode, the issuer's `GET /issuer-keys`, e.g. `https://<issuer-host>/issuer-keys` |
+| `ISSUER_KEYS_TTL_MS` | `300000` | how often the relay refreshes the cached issuer epoch public keys |
+| `TOKEN_PSS_SALT_LEN` | `48` | RSA-PSS salt length for token verification (matches SHA-384 and the issuer suite) |
+| `REDEMPTION_MAX_KEYS` | `5000000` | spend-once set memory bound (single replica; a shared store is the real fix) |
 | `RELAY_GATEWAY_SECRET` | (none) | shared secret sent to the gateway as `X-Columbia-Relay-Auth`; set the SAME value on the gateway |
 | `GATEWAY_CONFIGS_URL` | gateway host + `/ohttp-configs` | where the relay fetches the key config to pass through |
 | `CONFIG_TTL_MS` | `120000` | how long the relay caches the passed-through key config |
+| `REQUIRE_FDID` | (none) | when set, reject any request that did not arrive through the edge front door (see [Edge front door](#edge-front-door-cdn--waf)); unset disables the check |
 
 > The relay forwards only the ciphertext body plus `Content-Type: message/ohttp-req`. Dropping every client header is the security property, not an oversight. The one extra header it adds to the outbound request is `X-Columbia-Relay-Auth` (when `RELAY_GATEWAY_SECRET` is set), which identifies the relay, never the client.
 
 ## 5. (Optional) Build and run the commons cache
 
-The cache is an example upstream target for the gateway. It fetches a public, sessionless URL once and serves it to many, with TTL, stale-while-revalidate, and single-flight. It's generic: point it at whatever public content you want by adapting the upstream URL it builds in `server.js`. It has to be listed in the gateway's `ALLOWED_TARGET_ORIGINS`.
+The cache is an example upstream target for the gateway. It fetches a public, sessionless URL once and serves it to many, with TTL, stale-while-revalidate, and single-flight. It's generic: point it at whatever public content you want by setting `UPSTREAM_BASE` and `UPSTREAM_PATH_TEMPLATE`, no code edit needed. It has to be listed in the gateway's `ALLOWED_TARGET_ORIGINS`.
 
 ```sh
 cd ../commons-cache
@@ -123,6 +131,8 @@ docker run -d --name commons --network columbia -p 8082:8080 \
   -e PORT=8080 \
   -e COMMONS_TTL_MS=60000 \
   -e COMMONS_SWR_MS=300000 \
+  -e UPSTREAM_BASE="https://example.com" \
+  -e UPSTREAM_PATH_TEMPLATE="/{id}/{sort}.rss" \
   -e UPSTREAM_UA="columbia-commons/1.0 (+https://example.com)" \
   columbia-commons
 ```
@@ -132,11 +142,54 @@ docker run -d --name commons --network columbia -p 8082:8080 \
 | `PORT` | `8080` | listen port |
 | `COMMONS_TTL_MS` | `60000` | fresh window before an item is treated as stale (`X-Cache: HIT`) |
 | `COMMONS_SWR_MS` | `300000` | serve-stale window past TTL, with a background revalidate (`X-Cache: STALE`) |
+| `UPSTREAM_BASE` | `https://example.com` | upstream origin the cache fetches from; `https` only, validated at startup against private ranges so it can't be turned into an SSRF relay |
+| `UPSTREAM_PATH_TEMPLATE` | `/{id}/{sort}.rss` | path appended to `UPSTREAM_BASE`, with `{id}` and `{sort}` substituted (each sanitized then percent-encoded) |
 | `UPSTREAM_UA` | a generic UA string | `User-Agent` sent to the upstream origin |
+| `COMMONS_MAX_ENTRIES` | `5000` | LRU bound on cached keys |
+| `COMMONS_MAX_BODY_BYTES` | `5000000` | reject and never cache an upstream body larger than this |
 
 Responses carry `X-Cache: HIT|MISS|STALE` and CDN-ready `Cache-Control` and `Age` headers, so you can put a CDN in front later.
 
-## 6. Verify the path
+## 6. (Optional) Build and run the token issuer
+
+The issuer gates who may use the relay. It runs Apple App Attest verification and blind-signs anonymous tokens that the relay verifies offline. Run it only when the relay is in `CLIENT_AUTH_MODE=token`. It is the one component that learns a device identity, so run it under separate control that colludes with neither the relay nor the gateway. The wire format, the App Attest binding, and the epoch model are in [`token-issuer/PROTOCOL.md`](./token-issuer/PROTOCOL.md); the service's own walkthrough and the App Attest details are in [`token-issuer/README.md`](./token-issuer).
+
+The issuer fails closed: with no signing key, or with App Attest unconfigured, it rejects every `/issue` request.
+
+```sh
+cd ../token-issuer
+docker build -t columbia-token-issuer .
+
+docker run -d --name issuer --network columbia -p 8083:8080 \
+  -e PORT=8080 \
+  -e ISSUER_SIGNING_KEY="$(cat issuer_key.b64)" \
+  -e APPLE_APP_ATTEST_ROOT_CA_PEM_B64="$(cat apple_root_ca.b64)" \
+  -e APPLE_TEAM_ID="<your team id>" \
+  -e APPLE_BUNDLE_ID="<your bundle id>" \
+  columbia-token-issuer
+```
+
+| Env var | Required | Purpose |
+|---|---|---|
+| `ISSUER_SIGNING_KEY` | yes | the epoch RSA private key (2048-bit), a PEM string or base64 of DER, PKCS#1 or PKCS#8; injected at runtime, never committed; missing or unparseable fails closed |
+| `PORT` | `8080` | listen port |
+| `EPOCH_SECONDS` | `604800` | epoch length; the keypair rotates per epoch (default one week) |
+| `ISSUANCE_QUOTA_PER_EPOCH` | `256` | max tokens a single device may obtain per epoch; `0` disables the quota |
+| `MAX_TOKENS_PER_REQUEST` | `64` | max blinded messages accepted per `/issue` call |
+| `MAX_BODY_BYTES` | `262144` | request body cap |
+| `REQUIRE_CLIENT_DATA_BINDING` | `1` (on) | require the App Attest `clientDataHash` to commit to the exact `blinded[]` batch and epoch; set `0` only during client bring-up |
+| `APPLE_APP_ATTEST_ROOT_CA_PEM_B64` | to enforce | Apple's App Attest Root CA, PEM, base64; without it (and the two below) App Attest fails closed |
+| `APPLE_TEAM_ID` | to enforce | your Apple Team ID, the first half of the appID the attestation must match |
+| `APPLE_BUNDLE_ID` | to enforce | your app's bundle id, the second half of the appID |
+| `APPLE_APP_ATTEST_AAGUID` | `appattest` | `appattest` for production, `appattestdevelop` for dev or TestFlight builds |
+| `APP_ATTEST_CLOCK_SKEW_MS` | `300000` | tolerance when checking the attestation cert validity windows, for clock drift |
+| `REQUIRE_FDID` | (none) | when set, reject any request that did not arrive through the edge front door (see [Edge front door](#edge-front-door-cdn--waf)); `GET /health` and `GET /issuer-keys` stay reachable |
+
+> Generate a local test signing key with `openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -outform DER | base64 | tr -d '\n'`. In production the key comes from your secret store at runtime, never from the repo, exactly like the gateway's `SEED_SECRET_KEY`.
+
+Point the relay at the issuer by setting `CLIENT_AUTH_MODE=token` and `ISSUER_KEYS_URL=https://<issuer-host>/issuer-keys` on the relay. The relay fetches the issuer's epoch public keys once, caches them, and verifies every spent token offline, so there is no per-request call to the issuer.
+
+## 7. Verify the path
 
 Health-check each hop:
 
@@ -144,6 +197,7 @@ Health-check each hop:
 curl http://localhost:8080/health   # gateway
 curl http://localhost:8081/health   # relay
 curl http://localhost:8082/health   # commons cache
+curl http://localhost:8083/health   # token issuer (if running)
 ```
 
 To exercise the full encrypted path, use an OHTTP client. Fetch the gateway's key config (`/ohttp-configs`), HPKE-seal a `message/bhttp` request against it, and `POST` the resulting `message/ohttp-req` body to the relay. The relay returns the `message/ohttp-res` body for the client to open locally. Any RFC 9458 client library works, including the test client that ships with the upstream gateway.
@@ -154,16 +208,16 @@ The relay is the one public surface, so it carries the abuse controls. All of th
 
 - **Per-IP rate limiting and a concurrency cap.** `RATE_LIMIT_RPM` (default 120) bounds requests per minute per client IP over a `RATE_WINDOW_MS` window (default 60000); set `RATE_LIMIT_RPM=0` to disable it. `MAX_INFLIGHT` (default 256) caps concurrent relays across the whole process. Anything over either limit gets a 429. `RATE_MAX_KEYS` (default 100000) bounds the limiter's memory so a spoofed-source flood can't grow the table. Behind a managed ingress the per-IP key is read from the rightmost `X-Forwarded-For` entry, because the TCP peer is the ingress, not the client. That IP is used only as a transient counter key; it is never logged or forwarded to the gateway.
 - **Strict request shape.** The relay answers only `POST /relay` with `Content-Type: message/ohttp-req`. A wrong content type returns 415; any other path or method returns 404. There is no general proxy surface to probe.
-- **Client auth (`CLIENT_AUTH_MODE`).** `off` (default) relies on network controls only. `secret` requires a shared secret in the `CLIENT_AUTH_HEADER` (default `authorization`), checked in constant time against `CLIENT_SECRET`. Be honest about what this is: a shared secret shipped in a client is extractable, so `secret` mode is a speed-bump against casual abuse, not real client authentication. The mode is built as a pluggable hook so the intended design, App Attest plus blind-signed Privacy Pass tokens (`token` mode), slots in once the separate token issuer lands. `token` fails closed until then.
+- **Client auth (`CLIENT_AUTH_MODE`).** `off` (default) relies on network controls only. `secret` requires a shared secret in the `CLIENT_AUTH_HEADER` (default `x-lander-token`), checked in constant time against `CLIENT_SECRET`. Be honest about what this is: a shared secret shipped in a client is extractable, so `secret` mode is a speed-bump against casual abuse, not real client authentication. `token` mode is the real client gate: the relay reads the same header, verifies an anonymous blind-RSA token offline against the issuer's epoch public key, and enforces spend-once. Point it at the issuer with `ISSUER_KEYS_URL`; it fails closed if it has no issuer keys. See [section 6](#6-optional-build-and-run-the-token-issuer) and [`token-issuer/PROTOCOL.md`](./token-issuer/PROTOCOL.md).
 
 ## Single public surface (internal gateway and commons)
 
-The hardened posture is to make the relay the ONLY publicly reachable component and run the gateway and the commons cache on internal ingress, reachable only from inside the environment. This shrinks the attack surface to the one hop that has to be public, and it composes with the two-operator split below rather than replacing it: each operator still runs its own component, the gateway is just no longer exposed to the open internet.
+The hardened posture is to make the relay the ONLY publicly reachable component and run the gateway and the commons cache on internal ingress, reachable only from inside the environment. This shrinks the attack surface to the one hop that has to be public, and it composes with the two-operator split below rather than replacing it: each operator still runs its own component, the gateway just stays off the open internet.
 
 Two pieces make this work:
 
 - **Relay→gateway shared secret.** Set `RELAY_GATEWAY_SECRET` to the same value on the relay and the gateway. The relay attaches it as `X-Columbia-Relay-Auth` on every outbound request, and the gateway rejects `/gateway` traffic that lacks it (constant-time, before any HPKE work). Set it on the relay FIRST, then the gateway, so there is no window where the gateway 401s relay traffic. The value is constant across all requests, so it identifies the relay, never a client.
-- **Key-config passthrough.** With the gateway internal, clients can no longer reach its `GET /ohttp-configs` to fetch and pin the public key config. The relay proxies it: `GET /ohttp-configs` on the relay returns the gateway's key-config bytes verbatim, cached for `CONFIG_TTL_MS` (default 120000). The key config is public material clients are meant to pin, so passing it through leaks nothing. By default the relay fetches it from the gateway's own host; override with `GATEWAY_CONFIGS_URL` if it lives elsewhere.
+- **Key-config passthrough.** With the gateway internal, clients cannot reach its `GET /ohttp-configs` to fetch and pin the public key config. The relay proxies it: `GET /ohttp-configs` on the relay returns the gateway's key-config bytes verbatim, cached for `CONFIG_TTL_MS` (default 120000). The key config is public material clients are meant to pin, so passing it through leaks nothing. By default the relay fetches it from the gateway's own host; override with `GATEWAY_CONFIGS_URL` if it lives elsewhere.
 
 In production, also unregister the reflective self-test endpoints on the gateway by setting `ECHO_ENDPOINT=""` and `METADATA_ENDPOINT=""` (see [`ohttp-gateway/VENDORED.md`](./ohttp-gateway/VENDORED.md)).
 
@@ -173,6 +227,19 @@ In production, also unregister the reflective self-test endpoints on the gateway
 > - the gateway's `ALLOWED_TARGET_ORIGINS` to the commons cache's new internal hostname.
 >
 > Skip the repoint and the relay hits the public edge and gets a 404. Update these in lockstep with the ingress change.
+
+## Edge front door (CDN / WAF)
+
+A CDN or WAF in front of the two public origins (the relay and the issuer) absorbs DDoS and applies per-IP rate limiting at the edge, before traffic reaches your container. A managed front door is one way to run this; any CDN or WAF that can inject a request header the origin can verify works the same way.
+
+To stop someone from bypassing the front door and hitting the origin host directly, set `REQUIRE_FDID` on the relay and the issuer to the front door's identifier. Each origin reads the `X-Azure-FDID` request header and rejects any request whose value does not match `REQUIRE_FDID`. A managed Azure Front Door injects this header for its own profile id; a generic CDN or WAF works the same way as long as you configure it to inject a header named `X-Azure-FDID` carrying the value you set in `REQUIRE_FDID`, and to strip any client-supplied copy. A repeated header carrying several comma-joined values passes if any one of them matches. The comparison is constant-time and the value is never logged.
+
+- The check is inert when `REQUIRE_FDID` is unset, so you can deploy the origins first and turn the lock on once the front door is provisioned.
+- `GET /health` is exempt on both services, so the platform's in-environment health probe still passes.
+- The issuer also exempts `GET /issuer-keys`, because the relay fetches it directly, in-environment, and it is public key material.
+- Every other route requires the header: `POST /relay` and `GET /ohttp-configs` on the relay, and `POST /issue` on the issuer.
+
+This pairs with the single-public-surface posture above: the gateway and commons cache are internal, while the relay and issuer face the internet only through the front door.
 
 ## Running relay and gateway as separate operators
 
@@ -186,7 +253,7 @@ To split them:
 
 Now identity (relay, operator B) and content (gateway, operator A) live in separate trust domains, and linking you to what you fetched takes both operators colluding. For a stronger posture still, run the gateway in a confidential VM and have the client verify a hardware attestation before sealing. See [ARCHITECTURE.md](./ARCHITECTURE.md#attestation-chain-optional-advanced).
 
-> Secrets hygiene: never commit `SEED_SECRET_KEY`. Inject it at runtime from your host's secret store (a Docker secret, a systemd `EnvironmentFile` with `0600` perms, or a managed secrets service). Keep `LOG_SECRETS=false`. The repo's `.gitignore` already excludes `.env`, `*.seed`, and key material as a backstop.
+> Secrets hygiene: never commit `SEED_SECRET_KEY` or `ISSUER_SIGNING_KEY`. Inject them at runtime from your host's secret store (a Docker secret, a systemd `EnvironmentFile` with `0600` perms, or a managed secrets service). Keep `LOG_SECRETS=false`. The repo's `.gitignore` already excludes `.env`, `*.seed`, and key material as a backstop.
 
 ## Verifying the gateway
 
@@ -205,4 +272,4 @@ Plain Docker, as above, is the supported path. If you'd rather use a managed con
 | `CONTAINER_ENV` | your managed-container environment name |
 | `APP_NAME` | the name you want for the deployed app |
 
-The same three env-var contracts apply on any host: the gateway needs `SEED_SECRET_KEY` and `ALLOWED_TARGET_ORIGINS` (inject the seed from the host's secret store, never from the repo), the relay needs `GATEWAY_URL`, and the cache takes the optional `COMMONS_*` and `UPSTREAM_UA` knobs. And run the relay and gateway under separate operators for the non-collusion guarantee.
+The same env-var contracts apply on any host: the gateway needs `SEED_SECRET_KEY` and `ALLOWED_TARGET_ORIGINS` (inject the seed from the host's secret store, never from the repo), the relay needs `GATEWAY_URL`, the cache takes the optional `UPSTREAM_*` and `COMMONS_*` knobs, and the issuer (if you run `token` mode) needs `ISSUER_SIGNING_KEY` and the `APPLE_*` App Attest inputs, injected the same way. Run the relay and the gateway under separate operators for the non-collusion guarantee, and run the issuer under a third party that colludes with neither.

--- a/ohttp-relay/README.md
+++ b/ohttp-relay/README.md
@@ -29,7 +29,7 @@ sequenceDiagram
     participant commons as Commons Cache
 
     Note over client: HPKE-seal request
-    client->>relay: POST / · Content-Type message/ohttp-req · opaque ciphertext
+    client->>relay: POST /relay · Content-Type message/ohttp-req · opaque ciphertext
     Note over relay: strip ALL client headers + IP<br/>then fresh POST /gateway
     relay->>gateway: POST /gateway · Content-Type message/ohttp-req
     Note over gateway: HPKE-decapsulate<br/>to inner message/bhttp
@@ -54,7 +54,8 @@ sequenceDiagram
 | Route | Method | Purpose |
 |---|---|---|
 | `/health` | `GET` | liveness, returns `ok` |
-| `/` | `POST` | accepts a `message/ohttp-req` body, forwards it to the gateway's `/gateway`, returns the `message/ohttp-res` body verbatim |
+| `/relay` | `POST` | accepts a `message/ohttp-req` body, forwards it to the gateway's `/gateway`, returns the `message/ohttp-res` body verbatim |
+| `/ohttp-configs` | `GET` | proxies the gateway's public key config so clients can pin the key while the gateway stays internal |
 
 ## What it deliberately does not forward
 

--- a/ohttp-relay/server.js
+++ b/ohttp-relay/server.js
@@ -68,6 +68,15 @@ const REDEMPTION_MAX_KEYS = parseInt(process.env.REDEMPTION_MAX_KEYS || '5000000
 const RELAY_GATEWAY_SECRET = process.env.RELAY_GATEWAY_SECRET || '';
 const RELAY_GATEWAY_HEADER = 'x-columbia-relay-auth';
 
+// --- Front Door origin lock -------------------------------------------------
+// When set, the relay accepts a request only if it arrived through our Azure
+// Front Door, which injects the X-Azure-FDID header carrying our profile's
+// Front Door ID. This pins the public origin to Front Door so the Container App
+// FQDN can't be hit directly. Empty/unset => disabled (preserves current
+// behavior exactly), so the check is inert until an operator sets REQUIRE_FDID
+// at deploy time once Front Door is provisioned. The FDID value is NEVER logged.
+const REQUIRE_FDID = process.env.REQUIRE_FDID || '';
+
 // --- Public key-config passthrough ------------------------------------------
 // When the gateway runs internal-only, clients can no longer fetch its public
 // GET /ohttp-configs (the key config they pin). The relay — the sole public hop
@@ -313,6 +322,29 @@ function timingSafeEqualStr(presented, expected) {
   return crypto.timingSafeEqual(ha, hb);
 }
 
+// Front Door origin lock check. Returns true if the request is allowed to
+// proceed: either REQUIRE_FDID is unset (lock disabled) or the request carries a
+// matching X-Azure-FDID. A request may carry MULTIPLE x-azure-fdid values (Node
+// comma-joins a repeated header), so we split and accept if ANY token matches
+// REQUIRE_FDID via the constant-time compare. The header value is NEVER logged.
+function frontDoorAllowed(req) {
+  if (!REQUIRE_FDID) return true; // lock disabled => behavior unchanged
+  const raw = req.headers['x-azure-fdid'];
+  if (typeof raw !== 'string' || raw.length === 0) return false;
+  for (const tok of raw.split(',')) {
+    if (timingSafeEqualStr(tok.trim(), REQUIRE_FDID)) return true;
+  }
+  return false;
+}
+
+// The set of paths exempt from the Front Door origin lock. Only GET /health is
+// exempt on the relay: the platform health probe hits it in-environment with no
+// Front Door in that hop. Every other relay route (/relay, /ohttp-configs)
+// requires the FDID when REQUIRE_FDID is set.
+function fdidExempt(req, path) {
+  return req.method === 'GET' && path === '/health';
+}
+
 // Short-lived cache of the gateway's public key config. { body, contentType, fetchedAt }.
 let configCache = null;
 
@@ -376,6 +408,21 @@ function serveConfig(res, start) {
 
 const server = http.createServer((req, res) => {
   const start = Date.now();
+
+  // Front Door origin lock. When REQUIRE_FDID is set, every non-exempt request
+  // must arrive through Azure Front Door (which injects X-Azure-FDID). This runs
+  // BEFORE any route does work so a direct-to-origin hit is rejected up front.
+  // GET /health is exempt so the platform probe still passes. The FDID value is
+  // never logged; we log only the route + status. When REQUIRE_FDID is unset this
+  // whole block is a no-op and behavior is exactly as before.
+  if (REQUIRE_FDID) {
+    const path = String(req.url || '').split('?')[0];
+    if (!fdidExempt(req, path) && !frontDoorAllowed(req)) {
+      res.writeHead(403); res.end();
+      log({ route: path, status: 403, durationMs: Date.now() - start });
+      return;
+    }
+  }
 
   if (req.method === 'GET' && req.url === '/health') {
     res.writeHead(200, { 'Content-Type': 'text/plain' });

--- a/token-issuer/README.md
+++ b/token-issuer/README.md
@@ -140,6 +140,7 @@ so they self-expire when the epoch rolls.
 | `APPLE_APP_ATTEST_AAGUID` | `appattest` | `appattest` for production, `appattestdevelop` for dev/TestFlight builds |
 | `APP_ATTEST_CLOCK_SKEW_MS` | `300000` | tolerance (ms) when checking the x5c certs' validity windows, for issuer/Apple clock drift |
 | `REQUIRE_CLIENT_DATA_BINDING` | `1` (on) | require the App Attest `clientDataHash` to commit to the exact `blinded[]` batch + epoch (see below). Set to `0` only during client bring-up, before the iOS client computes the matching hash |
+| `REQUIRE_FDID` | unset | when set, reject any request whose `X-Azure-FDID` header does not match, so the issuer only accepts traffic that arrived through your front door (CDN/WAF). `/health` and `/issuer-keys` are exempt. Empty/unset disables the check |
 
 The signing key is injected exactly like the gateway's `SEED_SECRET_KEY`: from your
 host's secret store at runtime, never written to disk in this repo.

--- a/token-issuer/server.js
+++ b/token-issuer/server.js
@@ -75,6 +75,18 @@ const REQUIRE_CLIENT_DATA_BINDING = process.env.REQUIRE_CLIENT_DATA_BINDING !== 
 // for a single replica but NOT for multi-replica (see KEY STORE note).
 const ISSUER_SIGNING_KEY_B64 = process.env.ISSUER_SIGNING_KEY || '';
 
+// --- Front Door origin lock -------------------------------------------------
+// When set, the issuer accepts a request only if it arrived through our Azure
+// Front Door, which injects the X-Azure-FDID header carrying our profile's Front
+// Door ID. This pins the public origin to Front Door so the Container App FQDN
+// can't be hit directly. Empty/unset => disabled (preserves current behavior
+// exactly), so the check is inert until an operator sets REQUIRE_FDID at deploy
+// time once Front Door is provisioned. The FDID value is NEVER logged.
+// GET /health AND GET /issuer-keys are exempt: the relay fetches /issuer-keys
+// directly, in-environment, with no Front Door in that hop, and it is public key
+// material. Every other route (/issue and any /attest* endpoints) requires it.
+const REQUIRE_FDID = process.env.REQUIRE_FDID || '';
+
 // RSA-PSS / blind-RSA parameters. SHA-384, 2048-bit modulus, deterministic PSS -
 // the Apple PAT / RFC 9578 Token Type 2 suite.
 const RSA_MODULUS_BITS = 2048;
@@ -513,10 +525,62 @@ async function handleIssuerKeys(res, start) {
   log({ route: '/issuer-keys', status: 200, epoch: epochId, durationMs: Date.now() - start });
 }
 
+// --- Front Door origin lock -------------------------------------------------
+
+// Length-independent constant-time string compare (hash both sides so length
+// never leaks via timing; tolerates missing/short input). Mirrors the relay's
+// timingSafeEqualStr and the clientDataHash binding check, which already use
+// crypto.timingSafeEqual for constant-time comparison.
+function timingSafeEqualStr(presented, expected) {
+  if (typeof presented !== 'string' || presented.length === 0) return false;
+  const ha = crypto.createHash('sha256').update(presented).digest();
+  const hb = crypto.createHash('sha256').update(expected).digest();
+  return crypto.timingSafeEqual(ha, hb);
+}
+
+// Returns true if the request is allowed to proceed: either REQUIRE_FDID is unset
+// (lock disabled) or the request carries a matching X-Azure-FDID. A request may
+// carry MULTIPLE x-azure-fdid values (Node comma-joins a repeated header), so we
+// split and accept if ANY token matches REQUIRE_FDID via the constant-time
+// compare. The header value is NEVER logged.
+function frontDoorAllowed(req) {
+  if (!REQUIRE_FDID) return true; // lock disabled => behavior unchanged
+  const raw = req.headers['x-azure-fdid'];
+  if (typeof raw !== 'string' || raw.length === 0) return false;
+  for (const tok of raw.split(',')) {
+    if (timingSafeEqualStr(tok.trim(), REQUIRE_FDID)) return true;
+  }
+  return false;
+}
+
+// Paths exempt from the Front Door origin lock. GET /health is the platform probe
+// (in-environment, no Front Door hop). GET /issuer-keys is fetched directly by the
+// relay in-environment and is public key material. Every other route (/issue and
+// any /attest* endpoint) requires the FDID when REQUIRE_FDID is set.
+function fdidExempt(req, path) {
+  if (req.method !== 'GET') return false;
+  return path === '/health' || path === '/issuer-keys';
+}
+
 // --- HTTP server ------------------------------------------------------------
 
 const server = http.createServer((req, res) => {
   const start = Date.now();
+
+  // Front Door origin lock. When REQUIRE_FDID is set, every non-exempt request
+  // must arrive through Azure Front Door (which injects X-Azure-FDID). This runs
+  // BEFORE any route does work so a direct-to-origin hit is rejected up front.
+  // GET /health and GET /issuer-keys are exempt (see fdidExempt). The FDID value
+  // is never logged; we log only the route + status. When REQUIRE_FDID is unset
+  // this whole block is a no-op and behavior is exactly as before.
+  if (REQUIRE_FDID) {
+    const path = String(req.url || '').split('?')[0];
+    if (!fdidExempt(req, path) && !frontDoorAllowed(req)) {
+      res.writeHead(403); res.end();
+      log({ route: path, status: 403, durationMs: Date.now() - start });
+      return;
+    }
+  }
 
   if (req.method === 'GET' && req.url === '/health') {
     res.writeHead(200, { 'Content-Type': 'text/plain' });


### PR DESCRIPTION
Adds the REQUIRE_FDID front-door origin lock to the relay and issuer (reject traffic that did not arrive through the CDN/WAF; /health and /issuer-keys exempt), adds SECURITY.md, and objectively revises README/ARCHITECTURE/SELFHOSTING to describe the complete current system (token issuer, single public surface, abuse controls, edge front door). Trimmed stale/duplicated content; env vars verified against code; zero em dashes; no changelog framing.