### PR TITLE
Generalize public proxy: remove vendor-specific references and host coupling

### DIFF
--- a/.github/workflows/deploy-azure-reference.yml
+++ b/.github/workflows/deploy-azure-reference.yml
@@ -1,6 +1,8 @@
-# Deploy the middleware services to Azure Container Apps.
+# Optional reference deployment: build and ship the Columbia services to Azure
+# Container Apps. Columbia self-hosts on plain Docker on any host (see deploy/README.md);
+# this workflow is one example of automating that on one platform, not a requirement.
 #
-# Manual trigger only (workflow_dispatch) — there is no auto-deploy on push.
+# Manual trigger only (workflow_dispatch); there is no auto-deploy on push.
 # Images are built in ACR and tagged with the immutable commit SHA, then the
 # matching Container App is updated to that image.
 #
@@ -21,7 +23,7 @@
 # domain. The issuer's signing key and the Apple App Attest inputs are injected as
 # Container App secrets, never baked into the image. See token-issuer/README.md.
 
-name: Deploy middleware to Azure Container Apps
+name: Deploy Columbia services to Azure Container Apps (reference)
 
 on:
   workflow_dispatch:

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# Columbia — .gitignore
+# Columbia .gitignore
 #
 # CRITICAL: this repo must NEVER contain a real HPKE seed, key, token, or cred.
-# Inject the gateway's SEED_SECRET_KEY from your host's secret store at runtime —
-# nothing secret should ever be written to disk here. The patterns below are a
+# Inject the gateway's SEED_SECRET_KEY from your host's secret store at runtime.
+# Nothing secret should ever be written to disk here. The patterns below are a
 # belt-and-suspenders backstop. If you find a secret tracked, scrub it and
 # rotate the value.
 # ─────────────────────────────────────────────────────────────────────────────
@@ -37,7 +37,10 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
-package-lock.json    # services are dependency-free; no lockfile expected
+# Most services are dependency-free and ship no lockfile. The token-issuer is the
+# one service with npm dependencies, and it intentionally tracks its lockfile for
+# reproducible Docker builds via a directory-level negation in token-issuer/.gitignore.
+package-lock.json
 
 # ── Go build artifacts (vendored gateway) ──
 build/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A self-hostable HTTP proxy toolkit for personal use, built so that whoever runs the servers can't tell who fetched what. The privacy comes from what the system is unable to see, not from a promise that nobody will look.
 
-Columbia is named after Apollo 11's Command and Service Module, the ship that stayed up in orbit while the lander went down, with no view of what happened on the surface.
+Columbia is named after Apollo 11's Command and Service Module, the ship that stayed up in orbit while the lunar module descended to the surface, with no view of what happened down there.
 
 It's a small toolkit with almost no dependencies. You point it at HTTP content and fetch through a split-trust path built on OHTTP ([RFC 9458](https://www.rfc-editor.org/rfc/rfc9458)). Three services carry the request path (relay, gateway, commons cache), and a fourth optional service (the token issuer) gates who may use the relay without identifying them. Each is a service you run yourself, on plain Docker, on whatever host you want.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ Stop per-user key targeting, where a gateway hands one client a unique key to de
 The commons cache already emits CDN-ready headers. Put a CDN in front so public content is edge-cached globally and the cache tier only sees origin-shield traffic. It serves identical public content, so there's no per-user signal to leak.
 
 ### (g) Shared cache ⬜💲
-Right now each cache replica has its own in-memory store, so hit-rate drops as replicas fan out. A shared store (Redis, for instance) makes hit-rate replica-independent; keep single-flight across replicas with a distributed lock. Largely moot once (f) is in place.
+Each cache replica has its own in-memory store, so hit-rate drops as replicas fan out. A shared store (Redis, for instance) makes hit-rate replica-independent; keep single-flight across replicas with a distributed lock. Largely moot once (f) is in place.
 
 ### (h) Retries and resilience ⬜
 The relay and cache make single-attempt upstream calls today. Add bounded retries with backoff and jitter, per-call timeouts, and circuit-breaking, so a transient upstream hiccup doesn't surface as a user-visible failure. Keep it RED-observable.

--- a/SELFHOSTING.md
+++ b/SELFHOSTING.md
@@ -107,7 +107,7 @@ docker run -d --name relay --network columbia -p 8081:8080 \
 | `RATE_MAX_KEYS` | `100000` | hard cap on tracked IP keys, so a spoofed-source flood can't grow the table unbounded |
 | `CLIENT_AUTH_MODE` | `off` | client auth: `off`, `secret` (shared-secret header), or `token` (anonymous issuer token) |
 | `CLIENT_SECRET` | (none) | shared secret required when `CLIENT_AUTH_MODE=secret` |
-| `CLIENT_AUTH_HEADER` | `x-lander-token` | header the client presents its credential in (both `secret` and `token` modes read it) |
+| `CLIENT_AUTH_HEADER` | `x-columbia-token` | header the client presents its credential in (both `secret` and `token` modes read it) |
 | `ISSUER_KEYS_URL` | (none) | in `token` mode, the issuer's `GET /issuer-keys`, e.g. `https://<issuer-host>/issuer-keys` |
 | `ISSUER_KEYS_TTL_MS` | `300000` | how often the relay refreshes the cached issuer epoch public keys |
 | `TOKEN_PSS_SALT_LEN` | `48` | RSA-PSS salt length for token verification (matches SHA-384 and the issuer suite) |
@@ -208,7 +208,7 @@ The relay is the one public surface, so it carries the abuse controls. All of th
 
 - **Per-IP rate limiting and a concurrency cap.** `RATE_LIMIT_RPM` (default 120) bounds requests per minute per client IP over a `RATE_WINDOW_MS` window (default 60000); set `RATE_LIMIT_RPM=0` to disable it. `MAX_INFLIGHT` (default 256) caps concurrent relays across the whole process. Anything over either limit gets a 429. `RATE_MAX_KEYS` (default 100000) bounds the limiter's memory so a spoofed-source flood can't grow the table. Behind a managed ingress the per-IP key is read from the rightmost `X-Forwarded-For` entry, because the TCP peer is the ingress, not the client. That IP is used only as a transient counter key; it is never logged or forwarded to the gateway.
 - **Strict request shape.** The relay answers only `POST /relay` with `Content-Type: message/ohttp-req`. A wrong content type returns 415; any other path or method returns 404. There is no general proxy surface to probe.
-- **Client auth (`CLIENT_AUTH_MODE`).** `off` (default) relies on network controls only. `secret` requires a shared secret in the `CLIENT_AUTH_HEADER` (default `x-lander-token`), checked in constant time against `CLIENT_SECRET`. Be honest about what this is: a shared secret shipped in a client is extractable, so `secret` mode is a speed-bump against casual abuse, not real client authentication. `token` mode is the real client gate: the relay reads the same header, verifies an anonymous blind-RSA token offline against the issuer's epoch public key, and enforces spend-once. Point it at the issuer with `ISSUER_KEYS_URL`; it fails closed if it has no issuer keys. See [section 6](#6-optional-build-and-run-the-token-issuer) and [`token-issuer/PROTOCOL.md`](./token-issuer/PROTOCOL.md).
+- **Client auth (`CLIENT_AUTH_MODE`).** `off` (default) relies on network controls only. `secret` requires a shared secret in the `CLIENT_AUTH_HEADER` (default `x-columbia-token`), checked in constant time against `CLIENT_SECRET`. Be honest about what this is: a shared secret shipped in a client is extractable, so `secret` mode is a speed-bump against casual abuse, not real client authentication. `token` mode is the real client gate: the relay reads the same header, verifies an anonymous blind-RSA token offline against the issuer's epoch public key, and enforces spend-once. Point it at the issuer with `ISSUER_KEYS_URL`; it fails closed if it has no issuer keys. See [section 6](#6-optional-build-and-run-the-token-issuer) and [`token-issuer/PROTOCOL.md`](./token-issuer/PROTOCOL.md).
 
 ## Single public surface (internal gateway and commons)
 
@@ -263,7 +263,7 @@ Now identity (relay, operator B) and content (gateway, operator A) live in separ
 
 ## Optional: one example cloud deployment
 
-Plain Docker, as above, is the supported path. If you'd rather use a managed container host, the pattern is the same: build the image, push it to a registry, and run it as a container with the same env vars. The repo includes one example script, [`commons-cache/deploy-ghcr.sh`](./commons-cache/deploy-ghcr.sh), that builds the cache image, pushes it to a container registry, and creates or updates a managed container app. It uses placeholder names you have to replace:
+Plain Docker, as above, is the supported path. If you'd rather use a managed container host, the pattern is the same: build the image, push it to a registry, and run it as a container with the same env vars. [`deploy/README.md`](./deploy/README.md) collects the deployment notes and points to one example CI automation in [`.github/workflows/deploy-azure-reference.yml`](./.github/workflows/deploy-azure-reference.yml). The repo also includes one example script, [`commons-cache/deploy-ghcr.sh`](./commons-cache/deploy-ghcr.sh), that builds the cache image, pushes it to a container registry, and creates or updates a managed container app. It uses placeholder names you have to replace:
 
 | Placeholder in the script | Replace with |
 |---|---|

--- a/commons-cache/Dockerfile
+++ b/commons-cache/Dockerfile
@@ -1,4 +1,4 @@
-# Columbia — commons-cache origin
+# Columbia - commons-cache origin
 # Dependency-free Node service (global fetch + built-in http). Tiny image.
 # pin by @sha256:<digest> in CI for full reproducibility
 FROM node:20.18.1-alpine

--- a/commons-cache/README.md
+++ b/commons-cache/README.md
@@ -26,7 +26,7 @@ This service is the cache origin at the end of the operator-blind path (`relay -
 | `COMMONS_TTL_MS` | `60000` | fresh window before a feed is treated as stale |
 | `COMMONS_SWR_MS` | `300000` | serve-stale window past TTL (background revalidate) |
 | `UPSTREAM_BASE` | `https://example.com` | upstream origin the cache fetches from (https only, validated at startup) |
-| `UPSTREAM_PATH_TEMPLATE` | `/{id}/{sort}.rss` | path appended to `UPSTREAM_BASE`, with `{id}` and `{sort}` substituted (each sanitized then percent-encoded). Set the layout for your upstream without editing code, for example `/r/{id}/{sort}/.rss`. |
+| `UPSTREAM_PATH_TEMPLATE` | `/{id}/{sort}.rss` | path appended to `UPSTREAM_BASE`, with `{id}` and `{sort}` substituted (each sanitized then percent-encoded). Set the layout for your upstream without editing code, for example `/feed/{id}/{sort}.xml`. |
 | `UPSTREAM_UA` | a generic UA string | `User-Agent` sent to the upstream origin |
 
 ## Observability

--- a/commons-cache/server.js
+++ b/commons-cache/server.js
@@ -1,11 +1,11 @@
-// Columbia — commons-cache
+// Columbia - commons-cache
 //
 // The optional "public commons" tier: fetch each public, sessionless item ONCE
 // and serve it to all clients, fronted by OHTTP so the operator can't
 // profile reads. This service is the cache origin.
 //
 // Dependency-free (Node 20+: global fetch + built-in http). Structured JSON logs
-// to stdout carry RED metrics only — NO IPs, NO user data, NO request bodies —
+// to stdout carry RED metrics only - NO IPs, NO user data, NO request bodies -
 // matching the privacy-preserving observability design.
 //
 // Generic by design: it caches a public, sessionless upstream URL. Set the
@@ -14,10 +14,10 @@
 // reach this path.
 //
 // Endpoints:
-//   GET /health     — liveness
-//   GET /v1/probe   — diagnostic: can THIS host reach the configured upstream
+//   GET /health     - liveness
+//   GET /v1/probe   - diagnostic: can THIS host reach the configured upstream
 //                     surfaces at all? Reports status, size, and latency.
-//   GET /v1/commons — cached public feed (TTL + stale-while-revalidate)
+//   GET /v1/commons - cached public feed (TTL + stale-while-revalidate)
 //                     ?id=<feed-id>&sort=<sort>
 
 const http = require('http');
@@ -28,7 +28,7 @@ const SWR_MS = parseInt(process.env.COMMONS_SWR_MS || '300000', 10);       // se
 const UPSTREAM_BASE = (process.env.UPSTREAM_BASE || 'https://example.com').replace(/\/+$/, '');
 // Path appended to UPSTREAM_BASE, with {id} and {sort} substituted (each
 // sanitized and percent-encoded). Default is the generic form; an operator can
-// set e.g. /r/{id}/{sort}/.rss to target a specific upstream without a code edit.
+// set e.g. /feed/{id}/{sort}.xml to target a specific upstream without a code edit.
 const UPSTREAM_PATH_TEMPLATE = process.env.UPSTREAM_PATH_TEMPLATE || '/{id}/{sort}.rss';
 const UPSTREAM_UA = process.env.UPSTREAM_UA ||
   'columbia-commons/1.0 (+https://example.com)';
@@ -36,7 +36,7 @@ const MAX_ENTRIES = parseInt(process.env.COMMONS_MAX_ENTRIES || '5000', 10);    
 const MAX_BODY_BYTES = parseInt(process.env.COMMONS_MAX_BODY_BYTES || '5000000', 10); // reject oversized bodies
 
 // A sort/view is any short lowercase token. This validates input (prevents path
-// injection); it deliberately fixes no vocabulary — your upstream defines it.
+// injection); it deliberately fixes no vocabulary - your upstream defines it.
 const SORT_RE = /^[a-z]+$/;
 
 // Feed media types we are willing to echo back. Anything else is normalized to
@@ -111,7 +111,7 @@ async function fetchUpstream(url) {
   try {
     const res = await fetch(url, {
       headers: upstreamHeaders(),
-      redirect: 'manual',                 // never follow — a 3xx could point at an internal host (SSRF)
+      redirect: 'manual',                 // never follow - a 3xx could point at an internal host (SSRF)
       signal: AbortSignal.timeout(10000), // bound slow/hung upstreams
     });
     // Treat any 3xx as an upstream error: we do not follow redirects.
@@ -119,13 +119,13 @@ async function fetchUpstream(url) {
       return { status: res.status, body: Buffer.alloc(0), contentType: 'application/octet-stream', ms: Date.now() - started, error: true };
     }
     const body = Buffer.from(await res.arrayBuffer());
-    // Reject oversized bodies — do not cache or serve (memory DoS guard).
+    // Reject oversized bodies - do not cache or serve (memory DoS guard).
     if (res.status === 200 && body.length > MAX_BODY_BYTES) {
       return { status: res.status, body: Buffer.alloc(0), contentType: 'application/octet-stream', ms: Date.now() - started, error: true };
     }
     return { status: res.status, body, contentType: res.headers.get('content-type') || 'application/json', ms: Date.now() - started };
   } catch {
-    // Never surface the exception text — fixed, empty error result only.
+    // Never surface the exception text - fixed, empty error result only.
     return { status: 0, body: Buffer.alloc(0), contentType: 'application/octet-stream', ms: Date.now() - started, error: true };
   }
 }
@@ -162,20 +162,20 @@ async function getCachedFeed(id, sort) {
             }
           })
           .catch(() => {})
-          .finally(() => { entry.revalidating = false; }); // always reset — never get stuck revalidating
+          .finally(() => { entry.revalidating = false; }); // always reset - never get stuck revalidating
       }
       return { ...entry, cacheState: 'STALE' };
     }
   }
 
-  // Cold or rotten — fetch synchronously.
+  // Cold or rotten - fetch synchronously.
   const up = await fetchUpstream(url);
   if (up.status === 200 && !up.error) {
     const fresh = { body: up.body, contentType: safeContentType(up.contentType), fetchedAt: Date.now(), revalidating: false };
     cacheSet(key, fresh);
     return { ...fresh, cacheState: 'MISS', upstreamStatus: up.status, upstreamMs: up.ms };
   }
-  // Upstream failed — fixed error result, no upstream body/status leaked downstream.
+  // Upstream failed - fixed error result, no upstream body/status leaked downstream.
   return { cacheState: 'MISS', upstreamStatus: up.status, upstreamMs: up.ms, upstreamError: true };
 }
 
@@ -219,7 +219,7 @@ const server = http.createServer(async (req, res) => {
         const out = await getCachedFeed(id, sort);
         cacheState = out.cacheState;
         if (out.upstreamError) {
-          // Fixed 502 — never leak upstream status, body, or error text.
+          // Fixed 502 - never leak upstream status, body, or error text.
           status = 502;
           res.writeHead(status, {
             'Content-Type': 'application/json',
@@ -248,13 +248,13 @@ const server = http.createServer(async (req, res) => {
       res.end(JSON.stringify({ error: 'not found', routes: ['/health', '/v1/probe', '/v1/commons?id=&sort='] }));
     }
   } catch {
-    // Fixed 500 — never place exception text into the response body.
+    // Fixed 500 - never place exception text into the response body.
     status = 500;
     res.writeHead(status, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: 'internal' }));
   }
 
-  // RED metric — route TEMPLATE only, no IPs, no query values, no bodies.
+  // RED metric - route TEMPLATE only, no IPs, no query values, no bodies.
   log({ route, method: req.method, status, cache: cacheState, durationMs: Date.now() - started });
 });
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,36 @@
+# Deploying Columbia
+
+Columbia is a set of plain Docker services. It self-hosts on any host that can run
+containers: a single VM, a container platform, a Kubernetes cluster, or your own
+machine for testing. There is no required platform and no required orchestrator.
+
+The authoritative, host-agnostic build and run instructions live in
+[`../SELFHOSTING.md`](../SELFHOSTING.md). Follow that for the canonical setup:
+generate the gateway HPKE seed, build each service image, run the relay and gateway
+under separate operators so the non-collusion property holds, and (optionally) add
+the commons cache and token issuer.
+
+## Reference automation (one example)
+
+[`.github/workflows/deploy-azure-reference.yml`](../.github/workflows/deploy-azure-reference.yml)
+is one example of automating a deployment, targeting Azure Container Apps. It is
+optional and not required to run Columbia. Use it as a template if you deploy on
+Azure, or adapt the same build-and-update steps to whatever container host you run.
+
+The shape it follows is portable to any host:
+
+1. Build each service image from its directory (`ohttp-relay/`, `ohttp-gateway/`,
+   `commons-cache/`, `token-issuer/`).
+2. Tag the image with the immutable commit SHA.
+3. Roll the running service to the new image.
+4. Inject every secret (the gateway `SEED_SECRET_KEY`, the issuer signing key, the
+   Apple App Attest inputs, any shared secrets) from the host's secret store at
+   runtime. Nothing secret is baked into an image or committed to this repo.
+
+## Non-collusion
+
+Whatever host you pick, the operator-blind guarantee holds only when the relay and
+the gateway (and the token issuer, if used) are run by separate, non-colluding
+operators in separate trust domains. Running everything under one operator validates
+the flow but provides no protection against that single operator. See
+[`../SELFHOSTING.md`](../SELFHOSTING.md) for the non-collusion model.

--- a/ohttp-relay/Dockerfile
+++ b/ohttp-relay/Dockerfile
@@ -1,4 +1,4 @@
-# Columbia — OHTTP relay
+# Columbia - OHTTP relay
 # pin by @sha256:<digest> in CI for full reproducibility
 FROM node:20.18.1-alpine
 WORKDIR /app

--- a/ohttp-relay/server.js
+++ b/ohttp-relay/server.js
@@ -1,16 +1,16 @@
-// Columbia — OHTTP relay (RFC 9458)
+// Columbia - OHTTP relay (RFC 9458)
 //
 // The relay is the split-trust counterpart to the gateway. It sees the client's
-// IP and an OPAQUE ciphertext (message/ohttp-req) — never the plaintext, never
+// IP and an OPAQUE ciphertext (message/ohttp-req) - never the plaintext, never
 // the target. It forwards the ciphertext to the gateway, stripping every
 // identifying header, and returns the encapsulated response. The gateway sees
 // the relay's IP + plaintext but NOT the client's IP. Neither party ever holds
-// identity + content together — that's the operator-blind property.
+// identity + content together - that's the operator-blind property.
 //
 // NON-COLLUSION CAVEAT: for the security guarantee, relay and gateway MUST be
 // run by different, non-colluding operators. Running both on one host validates
 // the flow but provides no protection against the single operator. See
-// ../SELFHOSTING.md. Logs are RED-only — no IP, no content, no headers.
+// ../SELFHOSTING.md. Logs are RED-only - no IP, no content, no headers.
 
 const http = require('http');
 const https = require('https');
@@ -41,12 +41,12 @@ const RATE_MAX_KEYS  = parseInt(process.env.RATE_MAX_KEYS  || '100000', 10);// b
 // The verify function is pluggable so 'token' slots in without restructuring.
 const CLIENT_AUTH_MODE = (process.env.CLIENT_AUTH_MODE || 'off').toLowerCase();
 const CLIENT_SECRET    = process.env.CLIENT_SECRET || '';
-// Header the client presents its credential in. Default 'x-lander-token' so the
-// token mode reads exactly what the app sends (one header carrying the whole
+// Header the client presents its credential in. Default 'x-columbia-token' so the
+// token mode reads exactly what the client sends (one header carrying the whole
 // PrivateToken envelope) with no extra config. The 'secret' mode reuses the same
 // header. An operator may override to 'authorization' if they prefer to carry the
 // token there; the client would then send the same value under that header.
-const CLIENT_AUTH_HEADER = (process.env.CLIENT_AUTH_HEADER || 'x-lander-token').toLowerCase();
+const CLIENT_AUTH_HEADER = (process.env.CLIENT_AUTH_HEADER || 'x-columbia-token').toLowerCase();
 
 // --- Token mode (Privacy Pass / Private Access Token) -----------------------
 // In 'token' mode the client presents an anonymous, unlinkable blind-RSA token in
@@ -68,19 +68,19 @@ const REDEMPTION_MAX_KEYS = parseInt(process.env.REDEMPTION_MAX_KEYS || '5000000
 const RELAY_GATEWAY_SECRET = process.env.RELAY_GATEWAY_SECRET || '';
 const RELAY_GATEWAY_HEADER = 'x-columbia-relay-auth';
 
-// --- Front Door origin lock -------------------------------------------------
-// When set, the relay accepts a request only if it arrived through our Azure
-// Front Door, which injects the X-Azure-FDID header carrying our profile's
-// Front Door ID. This pins the public origin to Front Door so the Container App
-// FQDN can't be hit directly. Empty/unset => disabled (preserves current
-// behavior exactly), so the check is inert until an operator sets REQUIRE_FDID
-// at deploy time once Front Door is provisioned. The FDID value is NEVER logged.
+// --- Front door origin lock -------------------------------------------------
+// When set, the relay accepts a request only if it arrived through a front door
+// (a CDN or WAF, for example Azure Front Door), which injects the X-Azure-FDID
+// header carrying the front door's profile id. This pins the public origin to the
+// front door so the origin host can't be hit directly. Empty/unset => disabled,
+// so the check is inert until an operator sets REQUIRE_FDID at deploy time once a
+// front door is provisioned. The FDID value is NEVER logged.
 const REQUIRE_FDID = process.env.REQUIRE_FDID || '';
 
 // --- Public key-config passthrough ------------------------------------------
 // When the gateway runs internal-only, clients can no longer fetch its public
-// GET /ohttp-configs (the key config they pin). The relay — the sole public hop
-// — proxies it: a read-only GET that returns the gateway's PUBLIC key-config
+// GET /ohttp-configs (the key config they pin). The relay - the sole public hop
+// - proxies it: a read-only GET that returns the gateway's PUBLIC key-config
 // bytes verbatim. This leaks nothing: the key config is public material clients
 // are MEANT to pin. Cached briefly so we don't hit the gateway per client.
 const CONFIG_TTL_MS = parseInt(process.env.CONFIG_TTL_MS || '120000', 10);
@@ -105,9 +105,9 @@ if (gw.protocol !== 'https:') {
 }
 const GW_PORT = gw.port || 443; // honor a non-default port instead of hardcoding 443
 
-// The gateway's /ohttp-configs URL — derived from GATEWAY_URL (same host) unless
-// explicitly overridden. The relay reaches the gateway at the same FQDN whether
-// the gateway is public or internal-only (same Container Apps environment).
+// The gateway's /ohttp-configs URL, derived from GATEWAY_URL (same host) unless
+// explicitly overridden. The relay reaches the gateway at the same host whether
+// the gateway is public or internal-only (same internal network).
 const GATEWAY_CONFIGS_URL = process.env.GATEWAY_CONFIGS_URL || `${gw.protocol}//${gw.host}/ohttp-configs`;
 let cfgGw = null;
 try { cfgGw = new URL(GATEWAY_CONFIGS_URL); } catch { cfgGw = null; }
@@ -118,10 +118,10 @@ try { cfgGw = new URL(GATEWAY_CONFIGS_URL); } catch { cfgGw = null; }
 const rateBuckets = new Map();
 let inflight = 0;
 
-// Rate-limit key: the client IP as seen by the TRUSTED ingress. Behind Azure
-// Container Apps, the TCP peer (socket.remoteAddress) is the ingress proxy, not
+// Rate-limit key: the client IP as seen by the TRUSTED ingress. Behind a managed
+// container platform, the TCP peer (socket.remoteAddress) is the ingress proxy, not
 // the client, so per-IP limiting must read the rightmost X-Forwarded-For entry
-// (the address the trusted ingress appended — a client-spoofed value can only
+// (the address the trusted ingress appended - a client-spoofed value can only
 // sit to its LEFT). Used ONLY as a transient limiter key; never logged, never
 // forwarded to the gateway.
 function clientIpKey(req) {
@@ -252,7 +252,7 @@ function tryRedeem(nullifier) {
 }
 
 // Token mode verification. The client presents, in the CLIENT_AUTH_HEADER (default
-// 'x-lander-token'), a compact token:
+// 'x-columbia-token'), a compact token:
 //   PrivateToken <base64url( JSON{ keyId, tokenInput, signature } )>
 // where the outer envelope is base64url and tokenInput + signature inside the JSON
 // are standard base64. signature is the finalized blind-RSA (RSA-PSS/SHA-384,
@@ -322,7 +322,7 @@ function timingSafeEqualStr(presented, expected) {
   return crypto.timingSafeEqual(ha, hb);
 }
 
-// Front Door origin lock check. Returns true if the request is allowed to
+// Front door origin lock check. Returns true if the request is allowed to
 // proceed: either REQUIRE_FDID is unset (lock disabled) or the request carries a
 // matching X-Azure-FDID. A request may carry MULTIPLE x-azure-fdid values (Node
 // comma-joins a repeated header), so we split and accept if ANY token matches
@@ -337,9 +337,9 @@ function frontDoorAllowed(req) {
   return false;
 }
 
-// The set of paths exempt from the Front Door origin lock. Only GET /health is
+// The set of paths exempt from the front door origin lock. Only GET /health is
 // exempt on the relay: the platform health probe hits it in-environment with no
-// Front Door in that hop. Every other relay route (/relay, /ohttp-configs)
+// front door in that hop. Every other relay route (/relay, /ohttp-configs)
 // requires the FDID when REQUIRE_FDID is set.
 function fdidExempt(req, path) {
   return req.method === 'GET' && path === '/health';
@@ -409,12 +409,12 @@ function serveConfig(res, start) {
 const server = http.createServer((req, res) => {
   const start = Date.now();
 
-  // Front Door origin lock. When REQUIRE_FDID is set, every non-exempt request
-  // must arrive through Azure Front Door (which injects X-Azure-FDID). This runs
+  // Front door origin lock. When REQUIRE_FDID is set, every non-exempt request
+  // must arrive through the front door (which injects X-Azure-FDID). This runs
   // BEFORE any route does work so a direct-to-origin hit is rejected up front.
   // GET /health is exempt so the platform probe still passes. The FDID value is
   // never logged; we log only the route + status. When REQUIRE_FDID is unset this
-  // whole block is a no-op and behavior is exactly as before.
+  // whole block is a no-op.
   if (REQUIRE_FDID) {
     const path = String(req.url || '').split('?')[0];
     if (!fdidExempt(req, path) && !frontDoorAllowed(req)) {
@@ -504,7 +504,7 @@ const server = http.createServer((req, res) => {
     const body = Buffer.concat(chunks);
 
     // Forward ONLY the opaque ciphertext + its content type. Deliberately send a
-    // fresh request with NO client headers, NO X-Forwarded-For — the gateway must
+    // fresh request with NO client headers, NO X-Forwarded-For - the gateway must
     // not learn who the client is. The ONLY additional header is the relay→gateway
     // shared secret, which identifies the RELAY (not the client) so the gateway
     // can refuse traffic that didn't come through us.
@@ -539,7 +539,7 @@ const server = http.createServer((req, res) => {
       gres.on('end', () => {
         if (respAborted) return;
         const rb = Buffer.concat(rc);
-        // Pin the response content-type — never echo the gateway's header back.
+        // Pin the response content-type - never echo the gateway's header back.
         res.writeHead(gres.statusCode || 502, { 'Content-Type': 'message/ohttp-res' });
         res.end(rb);
         log({ route: '/relay', status: gres.statusCode || 502, durationMs: Date.now() - start });

--- a/token-issuer/PROTOCOL.md
+++ b/token-issuer/PROTOCOL.md
@@ -5,16 +5,16 @@ Columbia's Privacy Pass token auth:
 
 - the **issuer** (`token-issuer/server.js` + `token-issuer/appattest.js`), which
   runs App Attest verification and blind-signs tokens,
-- the **app** (Lander's `AppAttestTokenClient.swift`), which attests the device,
-  blinds token nonces, unblinds the issuer's blind signatures, and spends the
-  finished tokens, and
+- the **client** (an iOS reference client using Apple App Attest), which attests
+  the device, blinds token nonces, unblinds the issuer's blind signatures, and
+  spends the finished tokens, and
 - the **relay** (`ohttp-relay/server.js`), which verifies a spent token offline
   and enforces spend-once.
 
-The issuer code is the source of truth. Where the app or the relay disagreed with
-it, they were changed to match, not the other way around. This document is derived
-from the issuer's actual code, so if the code and this doc ever drift, the code
-wins and this doc is the bug.
+The issuer code is the source of truth. This document is derived from the issuer's
+actual code, so if the code and this doc ever disagree, the code wins and this doc
+is the bug. A client and a relay that interoperate with the issuer match the issuer,
+not the reverse.
 
 Everything here is built so the one party that learns the device identity (the
 issuer, via App Attest) never sees the spent token, and the party that sees the
@@ -39,7 +39,7 @@ Two consequences of "deterministic / identity preparation" that the contract
 depends on:
 
 - `prepare(nonce)` returns the nonce bytes unchanged. So the **token input** the
-  relay verifies the signature over is exactly the 32 random nonce bytes the app
+  relay verifies the signature over is exactly the 32 random nonce bytes the client
   drew. There is no extra random prefix to carry.
 - A blinded message and a finished signature are each exactly 256 bytes (2048-bit
   RSA). The issuer rejects any blinded message that is not 256 bytes.
@@ -67,15 +67,13 @@ It is derived from public material only.
 
 Around an epoch boundary the issuer publishes BOTH the current and the previous
 epoch's public key, and accepts the App Attest binding hash computed against either
-the current or the previous epoch (see `/issue`). The app keeps tokens for both
+the current or the previous epoch (see `/issue`). The client keeps tokens for both
 live epochs and drops the rest.
 
 ## Endpoints (issuer)
 
 The issuer exposes exactly three routes. There is **no** `/attest-challenge` and
-**no** separate `/attest` endpoint. Registration happens inside `/issue`. (An
-earlier app proposal had those two endpoints; they do not exist on the issuer and
-were removed from the app.)
+**no** separate `/attest` endpoint. Registration happens inside `/issue`.
 
 ### GET /health
 
@@ -83,7 +81,7 @@ Liveness only. Returns `200` with the body `ok` (text/plain). No JSON.
 
 ### GET /issuer-keys
 
-Publishes the current and previous epoch RSA public keys so the relay (and the app)
+Publishes the current and previous epoch RSA public keys so the relay (and the client)
 can verify and blind against them. Public material only.
 
 Response `200`, `application/json`:
@@ -104,7 +102,7 @@ Response `200`, `application/json`:
   presence of a second entry as optional (a fresh issuer with one epoch of history
   may publish one).
 - `publicKeySpki` is the standard `SubjectPublicKeyInfo` DER of the RSA public key,
-  **base64** (not base64url). The app tolerates base64url too, but the issuer emits
+  **base64** (not base64url). The client tolerates base64url too, but the issuer emits
   base64.
 - On a missing or unreadable signing key the issuer returns `503` (fail closed),
   not an empty key list.
@@ -137,9 +135,9 @@ Field rules, exactly as the issuer enforces them:
   `attestation`. If both are absent the issuer rejects with `no_attestation_or_assertion`.
 - `clientDataHash` (required) is the **base64 of the 32 raw bytes** of the binding
   hash defined in the next section. It is NOT a JSON object, NOT a preimage, NOT
-  base64url. It must decode to exactly 32 bytes or the issuer rejects it. This is
-  the single field the earlier app version got most wrong: it was sending the
-  preimage bytes, not the 32-byte hash.
+  base64url. It must decode to exactly 32 bytes or the issuer rejects it. The
+  common implementation mistake is sending the preimage bytes here instead of the
+  32-byte hash.
 - `blinded` (required) is an array of 1..64 base64 blinded messages, each exactly
   256 bytes after decoding. Order is preserved into the response.
 
@@ -155,7 +153,7 @@ Response `200`, `application/json`:
 
 - `epoch` is the integer epoch the tokens were signed under.
 - `keyId` is the issuer **epoch public key id** (the same id `/issuer-keys`
-  publishes), NOT the device keyId. The app banks this with each finished token so
+  publishes), NOT the device keyId. The client banks this with each finished token so
   it can tell the relay which epoch key to verify under.
 - `blindSigs[i]` is the base64 blind signature over `blinded[i]`. Same order, same
   length. The issuer never unblinds, so it never sees the finished token.
@@ -172,7 +170,7 @@ Error responses (no body, status only):
 | `503` | the issuer has no usable signing key |
 | `500` | blind-sign or unhandled error |
 
-The app treats `401`/`403` as "re-attest needed" and a fresh attestation is sent on
+The client treats `401`/`403` as "re-attest needed" and a fresh attestation is sent on
 the next call.
 
 ## The binding hash (clientDataHash), byte for byte
@@ -237,18 +235,18 @@ differently.
 
 ### Epoch tolerance
 
-The app computes the hash against the epoch it last saw from `/issuer-keys`. If the
+The client computes the hash against the epoch it last saw from `/issuer-keys`. If the
 request crosses an epoch boundary the issuer may already be one epoch ahead, so the
 issuer accepts the hash computed against **either the current or the previous
-epoch** and compares both in constant time. The app should use the current
+epoch** and compares both in constant time. The client should use the current
 epoch's integer; the previous-epoch acceptance is just slack for the boundary.
 
 ## App Attest flow and ordering
 
 App Attest is two-phase. The issuer's `validateAppAttest` enforces all of it; the
-app drives it.
+client drives it.
 
-1. **Generate key (once per install).** The app calls
+1. **Generate key (once per install).** The client calls
    `DCAppAttestService.generateKey()` to mint a hardware-backed key and gets a
    `keyId`. It persists `keyId` in the Keychain.
 
@@ -270,7 +268,7 @@ app drives it.
    same call, applies the binding check + quota + blind-signs the batch. So the
    first call registers AND issues.
 
-3. **Every later `/issue` = assertion.** The app:
+3. **Every later `/issue` = assertion.** The client:
    - builds the batch and computes the binding hash for the current epoch,
    - calls `generateAssertion(keyId, clientDataHash: bindingHash)`,
    - POSTs `/issue` with `assertion` set (and no `attestation`).
@@ -282,9 +280,9 @@ app drives it.
 
 4. **Re-attest on rejection.** If the issuer has forgotten the device (process
    restart on a single-replica deployment) it answers an assertion with
-   `unknown_device_key`. App Attest only allows ONE `attestKey` per key, so the app
+   `unknown_device_key`. App Attest only allows ONE `attestKey` per key, so the client
    cannot re-attest the same key; on a persistent rejection it must mint a fresh
-   key and attest that. The app should clear its "registered" marker and retry with
+   key and attest that. The client should clear its "registered" marker and retry with
    a fresh attestation.
 
 There is no separate challenge round trip. The binding hash IS the challenge, and
@@ -292,16 +290,16 @@ because it is derived from the batch + epoch it is fresh by construction.
 
 ## Token presentation to the relay
 
-After unblinding, the app holds, per token:
+After unblinding, the client holds, per token:
 
 - `keyId`     : the issuer epoch public key id (from the `/issue` response),
 - `tokenInput`: the 32 nonce bytes (identity preparation, so prepared == nonce),
 - `signature` : the finished 256-byte RSA-PSS signature.
 
-It presents one token per relay POST in a single header. The agreed header name is:
+It presents one token per relay POST in a single header. The header name is:
 
 ```
-x-lander-token: PrivateToken <base64url( JSON{ keyId, tokenInput, signature } )>
+x-columbia-token: PrivateToken <base64url( JSON{ keyId, tokenInput, signature } )>
 ```
 
 - The value is a `PrivateToken ` prefix (the relay also accepts `Bearer `, or no
@@ -309,16 +307,14 @@ x-lander-token: PrivateToken <base64url( JSON{ keyId, tokenInput, signature } )>
   `{ "keyId": "...", "tokenInput": "<base64>", "signature": "<base64>" }`.
 - Inside that JSON, `tokenInput` and `signature` are **standard base64** (the relay
   decodes them with a base64 decoder). Only the outer envelope is base64url.
-- There is exactly ONE header. The earlier app proposal split this into
-  `x-lander-token` (signature only) plus `x-lander-token-epoch` (keyId). That cannot
-  work, because the relay needs `tokenInput` to verify the signature, and it reads a
-  single header containing the whole JSON. `x-lander-token-epoch` is gone; the keyId
-  travels inside the JSON.
+- There is exactly ONE header. The keyId travels inside the JSON, not in a separate
+  header, because the relay needs `tokenInput` to verify the signature and reads a
+  single header containing the whole JSON.
 
-The relay reads the header named by `CLIENT_AUTH_HEADER`, whose default is now
-`x-lander-token` so it matches what the app sends with no extra configuration. An
-operator may point it at `authorization` instead if they prefer to carry the token
-there; the app would then send the same value under that header.
+The relay reads the header named by `CLIENT_AUTH_HEADER`, whose default is
+`x-columbia-token` so it matches what the client sends with no extra configuration.
+An operator may point it at `authorization` instead if they prefer to carry the
+token there; the client would then send the same value under that header.
 
 ## Relay verification and spend-once
 
@@ -361,9 +357,9 @@ A cross-check vector pins the binding hash bytes on both sides:
 
 - issuer: `test.js` asserts `expectedClientDataHash(epoch, blinded)` for a fixed
   `(epoch, blinded)` input equals a known hex value.
-- app: `BlindRSATokenTests` recomputes the SAME construction in Swift for the SAME
-  input and asserts the SAME hex. If either side changes the byte layout, one of the
-  two tests goes red.
+- client: an equivalent test recomputes the SAME construction for the SAME input
+  and asserts the SAME hex. If either side changes the byte layout, one of the two
+  tests goes red.
 
 What the vector does NOT cover, and which still needs a physical device plus a live
 issuer to exercise end to end:
@@ -374,4 +370,4 @@ issuer to exercise end to end:
   spend at `/relay`.
 - Re-attestation after an issuer restart.
 
-Those are device-only and are called out in the PR notes.
+Those are device-only.

--- a/token-issuer/README.md
+++ b/token-issuer/README.md
@@ -1,8 +1,13 @@
 # token-issuer
 
-The token issuer is how Columbia answers a hard question: how do you let only the
-genuine Lander app use the relay, rate limit even your own users, and still never
-be able to link a user to the content they fetch?
+The token issuer is how Columbia answers a hard question: how do you let only a
+genuine, attested client use the relay, rate limit even your own users, and still
+never be able to link a user to the content they fetch?
+
+The issuer ships as a reference token-issuance gate for an iOS client using Apple
+App Attest. App Attest is inherently an Apple/iOS mechanism; on other platforms the
+attestation step is swapped for the equivalent device-integrity primitive and the
+rest of the Privacy Pass flow is unchanged.
 
 The answer is the Privacy Pass pattern (the same one Apple's Private Access Tokens
 use). This service plays the **Attester** and **Issuer** roles of the Privacy Pass
@@ -35,7 +40,7 @@ extended to "prove you're a real, rate-limited client" without a login.
                                                                 spend-once
 ```
 
-1. The device proves it is a genuine Lander install via Apple App Attest.
+1. The device proves it is a genuine install of the iOS client via Apple App Attest.
 2. The device blinds one or more token inputs locally and sends the blinded
    messages (never the inputs) to `POST /issue`.
 3. The issuer validates App Attest, checks the device's per-epoch quota, and
@@ -57,8 +62,8 @@ Tokens use. "Publicly verifiable" is the property that lets the relay verify a
 spent token offline with only the public key.
 
 The blind RSA math comes from `@cloudflare/blindrsa-ts`, Cloudflare's
-implementation of RFC 9474. It is the exact construction Apple uses, which is why
-it was chosen over rolling our own.
+implementation of RFC 9474. It is the exact construction Apple uses, which is the
+reason to use it rather than a hand-rolled implementation.
 
 ## Endpoints
 
@@ -136,11 +141,11 @@ so they self-expire when the epoch rolls.
 | `MAX_BODY_BYTES` | `262144` | request body cap |
 | `APPLE_APP_ATTEST_ROOT_CA_PEM_B64` | unset | Apple's App Attest Root CA, PEM, base64. Required to ENFORCE App Attest |
 | `APPLE_TEAM_ID` | unset | your Apple Team ID. Required to enforce App Attest |
-| `APPLE_BUNDLE_ID` | unset | Lander's bundle id. Required to enforce App Attest |
+| `APPLE_BUNDLE_ID` | unset | the iOS client's bundle id. Required to enforce App Attest |
 | `APPLE_APP_ATTEST_AAGUID` | `appattest` | `appattest` for production, `appattestdevelop` for dev/TestFlight builds |
 | `APP_ATTEST_CLOCK_SKEW_MS` | `300000` | tolerance (ms) when checking the x5c certs' validity windows, for issuer/Apple clock drift |
 | `REQUIRE_CLIENT_DATA_BINDING` | `1` (on) | require the App Attest `clientDataHash` to commit to the exact `blinded[]` batch + epoch (see below). Set to `0` only during client bring-up, before the iOS client computes the matching hash |
-| `REQUIRE_FDID` | unset | when set, reject any request whose `X-Azure-FDID` header does not match, so the issuer only accepts traffic that arrived through your front door (CDN/WAF). `/health` and `/issuer-keys` are exempt. Empty/unset disables the check |
+| `REQUIRE_FDID` | unset | when set, reject any request whose `X-Azure-FDID` header does not match, so the issuer only accepts traffic that arrived through your front door (a CDN or WAF, for example Azure Front Door). `/health` and `/issuer-keys` are exempt. Empty/unset disables the check |
 
 The signing key is injected exactly like the gateway's `SEED_SECRET_KEY`: from your
 host's secret store at runtime, never written to disk in this repo.
@@ -160,11 +165,11 @@ clientDataHash == SHA-256( utf8(epoch) || 0x00 || blinded[0] || 0x00 || blinded[
 where each `blinded[i]` is the raw (base64-decoded) blinded message, so the
 attestation/assertion is bound to the exact tokens being requested in this epoch
 (the current or previous epoch is accepted, to tolerate an epoch-boundary crossing).
-**The iOS client must compute its App Attest challenge as this same hash.** Until
-that client change ships, run with `REQUIRE_CLIENT_DATA_BINDING=0` (App Attest then
-bounds abuse per-device but does not bind the payload) and flip it on once the
-client matches. This is the one piece of the App Attest gate whose other half lives
-in the Lander app.
+**The iOS client must compute its App Attest challenge as this same hash.** Before
+the client computes the matching hash, run with `REQUIRE_CLIENT_DATA_BINDING=0`
+(App Attest then bounds abuse per-device but does not bind the payload) and flip it
+on once the client matches. This is the one piece of the App Attest gate whose other
+half lives in the iOS client.
 
 ## What is production ready vs what still needs work
 
@@ -188,9 +193,8 @@ these pieces.
 
 **Implemented:**
 
-- **Apple App Attest validation** (`appattest.js`). The full server-side check is
-  now implemented, per Apple's "Validating Apps That Connect to Your Server through
-  App Attest":
+- **Apple App Attest validation** (`appattest.js`). The full server-side check
+  follows Apple's "Validating Apps That Connect to Your Server through App Attest":
   - *Attestation* (one-time device registration): CBOR-decode the attestation
     object, verify the `x5c` certificate chain anchors to Apple's App Attest Root
     CA (real X.509 path + signature + validity checks via node's
@@ -212,9 +216,9 @@ these pieces.
   trust chain (a self-minted CA + leaf, built in pure JS in `appattest-fixtures.js`)
   that satisfies every Apple check, plus negative tests that each tampered field is
   rejected. The one remaining gap is a **real-device fixture**: a captured
-  attestation/assertion from a physical iPhone running Lander, validated against
-  Apple's real Root CA, to confirm byte-compatibility with Apple's actual encoder.
-  See the repo's roadmap and the PR notes for exactly how to capture one.
+  attestation/assertion from a physical iPhone running the iOS client, validated
+  against Apple's real Root CA, to confirm byte-compatibility with Apple's actual
+  encoder. See the capture procedure below.
 
 **Stubbed, and clearly marked as such:**
 
@@ -225,7 +229,7 @@ these pieces.
   gaps for a real multi-replica deployment: a device could get its full quota from
   each replica, a restart forgets prior spends, and a device registered on one
   replica is unknown to another (its assertions are rejected as `unknown_device_key`
-  until it re-attests; the Lander client handles this by re-attesting on rejection).
+  until it re-attests; the iOS client handles this by re-attesting on rejection).
   The code marks exactly where a shared atomic store goes (Redis `INCR`/`EXPIRE` for
   the quota keyed by a salted device hash, Redis `SET NX` with an epoch TTL for the
   redemption nullifiers, and a Redis hash per keyId for the attested key with a
@@ -235,16 +239,17 @@ these pieces.
   keyed by a salted hash of the keyId, so the store never holds anything
   user-linking.
 
-- **Attester / Issuer split.** Right now one service plays both Privacy Pass roles.
-  RFC 9576 allows splitting the Attester (which sees the device) from the Issuer
-  (which blind-signs) into separate parties for an even stronger posture. That split
-  is future work and is noted in the roadmap.
+- **Attester / Issuer split.** One service plays both Privacy Pass roles. RFC 9576
+  allows splitting the Attester (which sees the device) from the Issuer (which
+  blind-signs) into separate parties for an even stronger posture. That split is a
+  roadmap item.
 
 ## Deployment intent
 
-This becomes a separate, public Azure Container App, built and deployed the same
-way as the relay, gateway, and commons cache (see the repo's deploy workflow). Like
-the gateway, **it must be run such that it never colludes with the relay.** If one
+The issuer runs as a separate, public service, built and deployed the same way as
+the relay, gateway, and commons cache (plain Docker on any host; see [`deploy/`](../deploy)
+for one example). Like the gateway, **it must be run such that it never colludes
+with the relay.** If one
 operator ran both the issuer and the relay, it could line up "device D asked for
 tokens in epoch E" (the issuer's view) against "a token from epoch E was spent on
 content C" (the relay's view) and, with enough traffic analysis, start to undo the
@@ -286,7 +291,7 @@ node --test
 ```
 
 Run them under the deploy runtime (`node:20.18.1-alpine`), not a newer local node,
-since a node-version mismatch has crashed this service in production before:
+since a node-version mismatch can change runtime behavior between local and deploy:
 
 ```sh
 # from the repo root (the Privacy Pass test imports the sibling relay)
@@ -309,19 +314,19 @@ inputs. The synthetic trust chain is built in pure JS in `appattest-fixtures.js`
 
 ### Capturing a real-device fixture (required follow-up)
 
-The synthetic fixtures substitute one thing only - the trust anchor (our test root
+The synthetic fixtures substitute one thing only, the trust anchor (the test root
 in place of Apple's Root CA, injected exactly as an operator injects the real root).
 Every cryptographic and structural check is the production one. Still, before
 trusting this in production you should validate one **real** attestation from a
-physical iPhone running Lander, against Apple's real Root CA, to confirm
+physical iPhone running the iOS client, against Apple's real Root CA, to confirm
 byte-compatibility with Apple's actual CBOR/X.509 encoder. Two ways:
 
 1. **Debug capture endpoint (temporary).** Add a short-lived `POST /attest-debug`
    to a NON-production instance that takes `{ keyId, attestation, clientDataHash }`,
    runs `validateAppAttest` with the real `APPLE_*` env set, and returns the result
-   (and, in debug only, the failing check). Drive it from the Lander client's App
+   (and, in debug only, the failing check). Drive it from the iOS client's App
    Attest code path once, capture the request body, then **remove the endpoint**.
-2. **Captured fixture (preferred, permanent regression).** Have the Lander client
+2. **Captured fixture (preferred, permanent regression).** Have the iOS client
    log one real `attestation` + `clientDataHash` + `keyId` for a known challenge,
    paste them into a new test alongside the **real** Apple Root CA PEM (base64), and
    assert `validateAppAttest` returns `ok: true`. Because a real attestation is not

--- a/token-issuer/appattest.js
+++ b/token-issuer/appattest.js
@@ -1,8 +1,8 @@
 // Columbia - Apple App Attest validation (Attester role)
 //
 // This module is the gate that proves an /issue request comes from a genuine,
-// unmodified Lander install on real Apple hardware, before the issuer will
-// blind-sign any tokens. It implements the server side of Apple's
+// unmodified install of the iOS client on real Apple hardware, before the issuer
+// will blind-sign any tokens. It implements the server side of Apple's
 // DCAppAttestService: the one-time ATTESTATION that registers a hardware-backed
 // key, and the per-request ASSERTION that proves possession of that key.
 //
@@ -36,7 +36,7 @@ import crypto from 'node:crypto';
 const APPLE_ROOT_CA_PEM_B64 = process.env.APPLE_APP_ATTEST_ROOT_CA_PEM_B64 || '';
 
 // The app identity the attestation must match: appID = "<TeamID>.<BundleID>".
-// e.g. PRWUVMURYJ.com.wbs.lander
+// e.g. ABCDE12345.com.example.app
 const APPLE_TEAM_ID = process.env.APPLE_TEAM_ID || '';
 const APPLE_BUNDLE_ID = process.env.APPLE_BUNDLE_ID || '';
 

--- a/token-issuer/appattest.test.js
+++ b/token-issuer/appattest.test.js
@@ -31,9 +31,9 @@ import {
 
 // --- One canonical fixture drives the env config for the whole file ----------
 
-const APP_ID = 'PRWUVMURYJ.com.wbs.lander';
-const TEAM_ID = 'PRWUVMURYJ';
-const BUNDLE_ID = 'com.wbs.lander';
+const APP_ID = 'ABCDE12345.com.example.app';
+const TEAM_ID = 'ABCDE12345';
+const BUNDLE_ID = 'com.example.app';
 
 // Build the baseline (valid) fixture first so we can pin its root CA via env.
 const baseChallenge = crypto.randomBytes(32);
@@ -122,7 +122,7 @@ test('(b1) wrong rpIdHash (attestation for a different appID) is REJECTED', asyn
   // simplest is to mint under base's root key directly.
   const wrong = makeAttestationFixtureUnderRoot({
     rootKey: base.rootKey, interKey: base.interKey,
-    appId: 'PRWUVMURYJ.com.wbs.WRONG', aaguidLabel: 'appattest', challenge: crypto.randomBytes(32),
+    appId: 'ABCDE12345.com.example.WRONG', aaguidLabel: 'appattest', challenge: crypto.randomBytes(32),
   });
   const res = await validateAppAttest({ keyId: wrong.keyIdB64, attestation: wrong.attestationB64, clientDataHash: wrong.clientDataHashB64 });
   assert.strictEqual(res.ok, false);

--- a/token-issuer/server.js
+++ b/token-issuer/server.js
@@ -19,8 +19,8 @@
 // the relay. If one operator ran both, it could line up "device D asked for tokens
 // in epoch E" (issuer view) against "a token from epoch E was spent on content C"
 // (relay view) and, with enough traffic shaping, start to link device to content.
-// Deploy the issuer as its own public Azure Container App under separate control,
-// exactly like the gateway. See ./README.md.
+// Deploy the issuer as its own public service under separate control, exactly like
+// the gateway. See ./README.md.
 //
 // LOGGING IS RED-ONLY. We never log the device id (keyId), the App Attest
 // assertion, a blinded request, a blind signature, or anything else that could tie
@@ -75,15 +75,15 @@ const REQUIRE_CLIENT_DATA_BINDING = process.env.REQUIRE_CLIENT_DATA_BINDING !== 
 // for a single replica but NOT for multi-replica (see KEY STORE note).
 const ISSUER_SIGNING_KEY_B64 = process.env.ISSUER_SIGNING_KEY || '';
 
-// --- Front Door origin lock -------------------------------------------------
-// When set, the issuer accepts a request only if it arrived through our Azure
-// Front Door, which injects the X-Azure-FDID header carrying our profile's Front
-// Door ID. This pins the public origin to Front Door so the Container App FQDN
-// can't be hit directly. Empty/unset => disabled (preserves current behavior
-// exactly), so the check is inert until an operator sets REQUIRE_FDID at deploy
-// time once Front Door is provisioned. The FDID value is NEVER logged.
+// --- Front door origin lock -------------------------------------------------
+// When set, the issuer accepts a request only if it arrived through a front door
+// (a CDN or WAF, for example Azure Front Door), which injects the X-Azure-FDID
+// header carrying the front door's profile id. This pins the public origin to the
+// front door so the origin host can't be hit directly. Empty/unset => disabled, so
+// the check is inert until an operator sets REQUIRE_FDID at deploy time once a
+// front door is provisioned. The FDID value is NEVER logged.
 // GET /health AND GET /issuer-keys are exempt: the relay fetches /issuer-keys
-// directly, in-environment, with no Front Door in that hop, and it is public key
+// directly, in-environment, with no front door in that hop, and it is public key
 // material. Every other route (/issue and any /attest* endpoints) requires it.
 const REQUIRE_FDID = process.env.REQUIRE_FDID || '';
 
@@ -269,7 +269,7 @@ function reserveQuota(epochId, deviceId, n) {
 // ATTESTED-KEY STORE (production): this Map is in-process and resets on restart,
 // which has the same two multi-replica gaps the quota store has: a device
 // registered on replica A is unknown to replica B, and a restart forgets every
-// registration (forcing devices to re-attest, which the Lander client handles by
+// registration (forcing devices to re-attest, which the iOS client handles by
 // falling back to a fresh attestation when an assertion is rejected as unknown).
 // For a real multi-replica deployment, move this to the SAME shared store as the
 // quota/redemption state (e.g. Redis: a hash per keyId holding the SPKI PEM + last
@@ -365,7 +365,7 @@ async function handleIssue(req, res, start, body) {
   }
 
   // (a) Validate App Attest. This proves the request comes from a genuine,
-  // unmodified Lander install on real Apple hardware. FAILS CLOSED: if App Attest
+  // unmodified iOS client install on real Apple hardware. FAILS CLOSED: if App Attest
   // is unconfigured (Apple root cert / team+bundle id not supplied), the validator
   // returns { ok: false } and we reject. We never log the assertion/attestation,
   // and we never log the coarse failure reason at a level that could fingerprint a
@@ -567,12 +567,12 @@ function fdidExempt(req, path) {
 const server = http.createServer((req, res) => {
   const start = Date.now();
 
-  // Front Door origin lock. When REQUIRE_FDID is set, every non-exempt request
-  // must arrive through Azure Front Door (which injects X-Azure-FDID). This runs
+  // Front door origin lock. When REQUIRE_FDID is set, every non-exempt request
+  // must arrive through the front door (which injects X-Azure-FDID). This runs
   // BEFORE any route does work so a direct-to-origin hit is rejected up front.
   // GET /health and GET /issuer-keys are exempt (see fdidExempt). The FDID value
   // is never logged; we log only the route + status. When REQUIRE_FDID is unset
-  // this whole block is a no-op and behavior is exactly as before.
+  // this whole block is a no-op.
   if (REQUIRE_FDID) {
     const path = String(req.url || '').split('?')[0];
     if (!fdidExempt(req, path) && !frontDoorAllowed(req)) {


### PR DESCRIPTION
## Summary

Sanitize and generalize the public proxy so it carries no vendor-specific
references and reads as a host-neutral, self-hostable OHTTP toolkit. The result is
objective present-tense reference documentation and code, with deployment framed as
infrastructure-agnostic and Azure as one optional example.

## Scope

- Rename the client-auth header default from `x-lander-token` to `x-columbia-token`
  in the relay code, `token-issuer/PROTOCOL.md`, and `SELFHOSTING.md`.
- Reframe the token-issuer App Attest gate as a reference token-issuance gate for an
  iOS client. App Attest stays accurate as an Apple/iOS mechanism; other platforms
  swap the attestation primitive. No specific consumer app is named.
- Replace concrete example identifiers (team id, bundle id, appID) in the App Attest
  validator and its tests with generic example values (`ABCDE12345.com.example.app`).
- Generalize the commons-cache upstream path examples to neutral feed paths.
- Make the deploy story infrastructure-agnostic: rename the deploy workflow to
  `deploy-azure-reference.yml` with a header noting it is one optional reference
  deployment, and add `deploy/README.md` describing plain-Docker self-hosting on any
  host with Azure as one example.
- Resolve the lockfile/gitignore inconsistency: the token-issuer intentionally tracks
  its `package-lock.json` for reproducible Docker builds; the root `.gitignore`
  comment documents that intent instead of implying no lockfile is expected.
- Convert em dashes to ASCII in first-party code and docs.

## Verification

- `grep -ri lander .` (excluding `.git`): zero hits.
- `grep -riE "azurefd|azurecontainerapps|attest.azure" .`: zero real hosts.
- `grep -riE "BEGIN .*PRIVATE KEY|client_secret[:=]..."`: zero secrets.
- Em-dash scan of all changed files: zero.
- No subscription/tenant GUIDs, no tracked key/secret files, no hardcoded
  high-entropy secret literals.
- `token-issuer` test suite: 31/31 pass after the example-identifier rename.
- All edited JS passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLihriHmupL2kvLbcUEin7
