### PR TITLE
docs: retitle the Unreleased changelog notes as v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-Notable changes to Columbia. Releases are git tags; the most recent tagged release is `v1.2.0`. This file starts from the unreleased work that follows it.
+Notable changes to Columbia. Releases are git tags; the most recent tagged release is `v1.3.0`.
 
 ## Unreleased
+
+## v1.3.0 (2026-07-08)
 
 ### Documentation
 


### PR DESCRIPTION
The CHANGELOG's `## Unreleased` section is actually the v1.3.0 release content — v1.3.0 was tagged at the current `main` HEAD (2026-07-08) but the heading was never retitled, and the intro still names v1.2.0 as the latest tag.

This docs-only PR:
- retitles `## Unreleased` → `## v1.3.0 (2026-07-08)`
- updates the intro to name v1.3.0 as the most recent tag
- opens a fresh empty `## Unreleased` for future work

No code or protocol changes; no new release needed.