### PR TITLE
Make the front-door origin-lock header configurable (FDID_HEADER)

### DIFF
--- a/SELFHOSTING.md
+++ b/SELFHOSTING.md
@@ -120,6 +120,7 @@ docker run -d --name relay --network columbia -p 8081:8080 \
 | `GATEWAY_CONFIGS_URL` | gateway host + `/ohttp-configs` | where the relay fetches the key config to pass through |
 | `CONFIG_TTL_MS` | `120000` | how long the relay caches the passed-through key config |
 | `REQUIRE_FDID` | (none) | when set, reject any request that did not arrive through the edge front door (see [Edge front door](#edge-front-door-cdn--waf)); unset disables the check |
+| `FDID_HEADER` | `x-azure-fdid` | name of the header the edge front door injects for the `REQUIRE_FDID` lock above; override for a non-Azure CDN or WAF that injects a differently named header |
 
 > The relay forwards only the ciphertext body plus `Content-Type: message/ohttp-req`. Dropping every client header is the security property, not an oversight. The one extra header it adds to the outbound request is `X-Columbia-Relay-Auth` (when `RELAY_GATEWAY_SECRET` is set), which identifies the relay, never the client.
 
@@ -153,6 +154,7 @@ docker run -d --name commons --network columbia -p 8082:8080 \
 | `COMMONS_MAX_BODY_BYTES` | `5000000` | reject and never cache an upstream body larger than this |
 | `FORWARD_UPSTREAM_AUTH` | `off` | when on, forward the incoming request's `Authorization` header to the upstream on a MISS or a background revalidate, for an upstream that gates its PUBLIC listings behind a credential. The header is NEVER part of the cache key, so a HIT serves the shared public bytes with no credential. Forward ONLY an anonymous, app-level credential, and ONLY for the public-listing path template. A per-user token would get its per-user response cached under `(id, sort)` and served to another caller (see the safety invariant in [`commons-cache/README.md`](./commons-cache/README.md)) |
 | `REQUIRE_FDID` | (none) | when set, reject any request that did not arrive through the edge front door (see [Edge front door](#edge-front-door-cdn--waf)); the front door injects `X-Azure-FDID` and the cache checks it constant-time. Only `GET /health` is exempt. Unset disables the check |
+| `FDID_HEADER` | `x-azure-fdid` | name of the header the edge front door injects for the `REQUIRE_FDID` lock above; override for a non-Azure CDN or WAF that injects a differently named header |
 
 Responses carry `X-Cache: HIT|MISS|STALE` and CDN-ready `Cache-Control` and `Age` headers, so you can put a CDN in front later.
 
@@ -192,6 +194,7 @@ docker run -d --name issuer --network columbia -p 8083:8080 \
 | `APPLE_APP_ATTEST_AAGUID` | `appattest` | `appattest` for production, `appattestdevelop` for dev or TestFlight builds |
 | `APP_ATTEST_CLOCK_SKEW_MS` | `300000` | tolerance when checking the attestation cert validity windows, for clock drift |
 | `REQUIRE_FDID` | (none) | when set, reject any request that did not arrive through the edge front door (see [Edge front door](#edge-front-door-cdn--waf)); `GET /health` and `GET /issuer-keys` stay reachable |
+| `FDID_HEADER` | `x-azure-fdid` | name of the header the edge front door injects for the `REQUIRE_FDID` lock above; override for a non-Azure CDN or WAF that injects a differently named header |
 
 > Generate a local test signing key with `openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -outform DER | base64 | tr -d '\n'`. In production the key comes from your secret store at runtime, never from the repo, exactly like the gateway's `SEED_SECRET_KEY`.
 
@@ -282,7 +285,7 @@ In production, also unregister the reflective self-test endpoints on the gateway
 
 A CDN or WAF in front of the two public origins (the relay and the issuer) absorbs DDoS and applies per-IP rate limiting at the edge, before traffic reaches your container. A managed front door is one way to run this; any CDN or WAF that can inject a request header the origin can verify works the same way.
 
-To stop someone from bypassing the front door and hitting the origin host directly, set `REQUIRE_FDID` on the relay and the issuer to the front door's identifier. Each origin reads the `X-Azure-FDID` request header and rejects any request whose value does not match `REQUIRE_FDID`. A managed Azure Front Door injects this header for its own profile id; a generic CDN or WAF works the same way as long as you configure it to inject a header named `X-Azure-FDID` carrying the value you set in `REQUIRE_FDID`, and to strip any client-supplied copy. A repeated header carrying several comma-joined values passes if any one of them matches. The comparison is constant-time and the value is never logged.
+To stop someone from bypassing the front door and hitting the origin host directly, set `REQUIRE_FDID` on the relay and the issuer to the front door's identifier. Each origin reads the `X-Azure-FDID` request header and rejects any request whose value does not match `REQUIRE_FDID`. A managed Azure Front Door injects this header for its own profile id; a generic CDN or WAF works the same way as long as you configure it to inject a header named `X-Azure-FDID` (or whatever you set `FDID_HEADER` to) carrying the value you set in `REQUIRE_FDID`, and to strip any client-supplied copy. A repeated header carrying several comma-joined values passes if any one of them matches. The comparison is constant-time and the value is never logged.
 
 - The check is inert when `REQUIRE_FDID` is unset, so you can deploy the origins first and turn the lock on once the front door is provisioned.
 - `GET /health` is exempt on both services, so the platform's in-environment health probe still passes.

--- a/commons-cache/README.md
+++ b/commons-cache/README.md
@@ -50,6 +50,7 @@ Some public JSON APIs still require an app-level credential on the request even 
 | `COMMONS_MAX_BODY_BYTES` | `5000000` | reject and never cache an upstream body larger than this (memory-DoS guard) |
 | `FORWARD_UPSTREAM_AUTH` | `false` | when `true`, forward the incoming request's `Authorization` header to the upstream on a MISS/revalidation (for upstreams that gate public listings behind an anonymous app-level credential). The header is **never** part of the cache key; a HIT serves shared public bytes with no credential. Safe **only** for the public-listing path template. See the safety invariant above. |
 | `REQUIRE_FDID` | (none) | front-door origin lock. When set, reject any request that did not arrive through the edge front door, which injects `X-Azure-FDID`; the cache checks that header constant-time and 403s a mismatch. Only `GET /health` is exempt. Unset disables the check. See below. |
+| `FDID_HEADER` | `x-azure-fdid` | name of the header the edge front door injects for the `REQUIRE_FDID` lock above; override for a non-Azure CDN or WAF that injects a differently named header |
 
 ### Front-door origin lock (`REQUIRE_FDID`)
 

--- a/commons-cache/server.js
+++ b/commons-cache/server.js
@@ -31,6 +31,10 @@ const crypto = require('crypto');
 // burn the upstream credential budget). Inert until an operator sets REQUIRE_FDID.
 // The value is NEVER logged.
 const REQUIRE_FDID = process.env.REQUIRE_FDID || '';
+// Header the edge front door injects to prove a request came through it. Azure
+// Front Door uses X-Azure-FDID; override FDID_HEADER for a non-Azure CDN/WAF.
+// Node lowercases all incoming header names, so match on the lowercase form.
+const FDID_HEADER = (process.env.FDID_HEADER || 'x-azure-fdid').toLowerCase();
 
 const PORT = parseInt(process.env.PORT || '8080', 10); // non-root can't bind <1024
 const TTL_MS = parseInt(process.env.COMMONS_TTL_MS || '60000', 10);        // fresh window
@@ -267,7 +271,7 @@ function timingSafeEqualStr(presented, expected) {
 // present (a repeated header is comma-joined by Node; accept if ANY token matches).
 function frontDoorAllowed(req) {
   if (!REQUIRE_FDID) return true;
-  const raw = req.headers['x-azure-fdid'];
+  const raw = req.headers[FDID_HEADER];
   if (typeof raw !== 'string' || raw.length === 0) return false;
   for (const tok of raw.split(',')) {
     if (timingSafeEqualStr(tok.trim(), REQUIRE_FDID)) return true;

--- a/ohttp-relay/README.md
+++ b/ohttp-relay/README.md
@@ -93,6 +93,7 @@ No IP, no content, no headers, no target. `route` is a fixed template.
 | `RELAY_GATEWAY_SECRET` | (none) | shared secret sent to the gateway as `X-Columbia-Relay-Auth`; set the SAME value on the gateway so it rejects traffic that did not come through the relay |
 | `GATEWAY_CONFIGS_URL` | gateway host + `/ohttp-configs` | where the relay fetches the gateway key config it passes through at `GET /ohttp-configs` |
 | `REQUIRE_FDID` | (none) | front-door origin lock: when set, reject any request that did not arrive through the edge front door (which injects `X-Azure-FDID`). `GET /health` is exempt. Unset disables the check |
+| `FDID_HEADER` | `x-azure-fdid` | name of the header the edge front door injects for the `REQUIRE_FDID` lock above; override for a non-Azure CDN or WAF that injects a differently named header |
 
 ### Token mode (Privacy Pass)
 

--- a/ohttp-relay/server.js
+++ b/ohttp-relay/server.js
@@ -89,6 +89,10 @@ const RELAY_GATEWAY_HEADER = 'x-columbia-relay-auth';
 // so the check is inert until an operator sets REQUIRE_FDID at deploy time once a
 // front door is provisioned. The FDID value is NEVER logged.
 const REQUIRE_FDID = process.env.REQUIRE_FDID || '';
+// Header the edge front door injects to prove a request came through it. Azure
+// Front Door uses X-Azure-FDID; override FDID_HEADER for a non-Azure CDN/WAF.
+// Node lowercases all incoming header names, so match on the lowercase form.
+const FDID_HEADER = (process.env.FDID_HEADER || 'x-azure-fdid').toLowerCase();
 
 // --- Public key-config passthrough ------------------------------------------
 // When the gateway runs internal-only, clients can no longer fetch its public
@@ -352,7 +356,7 @@ function timingSafeEqualStr(presented, expected) {
 // REQUIRE_FDID via the constant-time compare. The header value is NEVER logged.
 function frontDoorAllowed(req) {
   if (!REQUIRE_FDID) return true; // lock disabled => behavior unchanged
-  const raw = req.headers['x-azure-fdid'];
+  const raw = req.headers[FDID_HEADER];
   if (typeof raw !== 'string' || raw.length === 0) return false;
   for (const tok of raw.split(',')) {
     if (timingSafeEqualStr(tok.trim(), REQUIRE_FDID)) return true;

--- a/token-issuer/README.md
+++ b/token-issuer/README.md
@@ -145,6 +145,7 @@ so they self-expire when the epoch rolls.
 | `APP_ATTEST_CLOCK_SKEW_MS` | `300000` | tolerance (ms) when checking the x5c certs' validity windows, for issuer/Apple clock drift |
 | `REQUIRE_CLIENT_DATA_BINDING` | `1` (on) | require the App Attest `clientDataHash` to commit to the exact `blinded[]` batch + epoch (see below). Set to `0` only during client bring-up, before the iOS client computes the matching hash |
 | `REQUIRE_FDID` | unset | when set, reject any request whose `X-Azure-FDID` header does not match, so the issuer only accepts traffic that arrived through your front door (a CDN or WAF, for example Azure Front Door). `/health` and `/issuer-keys` are exempt. Empty/unset disables the check |
+| `FDID_HEADER` | `x-azure-fdid` | name of the header the edge front door injects for the `REQUIRE_FDID` lock above; override for a non-Azure CDN or WAF that injects a differently named header |
 
 The signing key is injected exactly like the gateway's `SEED_SECRET_KEY`: from your
 host's secret store at runtime, never written to disk in this repo.

--- a/token-issuer/server.js
+++ b/token-issuer/server.js
@@ -87,6 +87,10 @@ const ISSUER_SIGNING_KEY_B64 = process.env.ISSUER_SIGNING_KEY || '';
 // directly, in-environment, with no front door in that hop, and it is public key
 // material. Every other route (/issue and any /attest* endpoints) requires it.
 const REQUIRE_FDID = process.env.REQUIRE_FDID || '';
+// Header the edge front door injects to prove a request came through it. Azure
+// Front Door uses X-Azure-FDID; override FDID_HEADER for a non-Azure CDN/WAF.
+// Node lowercases all incoming header names, so match on the lowercase form.
+const FDID_HEADER = (process.env.FDID_HEADER || 'x-azure-fdid').toLowerCase();
 
 // RSA-PSS / blind-RSA parameters. SHA-384, 2048-bit modulus, deterministic PSS -
 // the Apple PAT / RFC 9578 Token Type 2 suite.
@@ -546,7 +550,7 @@ function timingSafeEqualStr(presented, expected) {
 // compare. The header value is NEVER logged.
 function frontDoorAllowed(req) {
   if (!REQUIRE_FDID) return true; // lock disabled => behavior unchanged
-  const raw = req.headers['x-azure-fdid'];
+  const raw = req.headers[FDID_HEADER];
   if (typeof raw !== 'string' || raw.length === 0) return false;
   for (const tok of raw.split(',')) {
     if (timingSafeEqualStr(tok.trim(), REQUIRE_FDID)) return true;


### PR DESCRIPTION
The origin lock read the literal `x-azure-fdid` header, the last Azure-specific string in the lock path. This adds an `FDID_HEADER` env var (default `x-azure-fdid`) and reads that instead, in the relay, commons cache, and token issuer, so a self-hoster behind a non-Azure CDN or WAF can point the lock at whatever header their edge injects.

- Backward compatible: default is `x-azure-fdid`, so unset behaves exactly as before.
- Docs: `FDID_HEADER` added to each component env table and SELFHOSTING.md; front-door prose notes the header name is configurable.
- Verified: `node --check` on all three services; commons-cache self-tests pass.